### PR TITLE
CI: Upgrade ros-tooling/setup-ros

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,7 +17,7 @@ jobs:
       image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
       - name: Setup ROS 2
-        uses: ros-tooling/setup-ros@v0.3
+        uses: ros-tooling/setup-ros@v0.7
         with:
           required-ros-distributions: humble
       - name: Checkout repository


### PR DESCRIPTION
Fixes CI failures due to Empy version.

- See https://github.com/ros-tooling/setup-ros/pull/632