### PR TITLE
examples: rename navigation example executables

### DIFF
--- a/examples/cpp/navigation/global_navigation/CMakeLists.txt
+++ b/examples/cpp/navigation/global_navigation/CMakeLists.txt
@@ -18,12 +18,12 @@ find_package(rclcpp REQUIRED)
 find_package(px4_ros2_cpp REQUIRED)
 
 include_directories(include ${Eigen3_INCLUDE_DIRS})
-add_executable(example_global_navigation_cpp
+add_executable(example_global_navigation
         src/main.cpp)
-ament_target_dependencies(example_global_navigation_cpp Eigen3 px4_ros2_cpp rclcpp)
+ament_target_dependencies(example_global_navigation Eigen3 px4_ros2_cpp rclcpp)
 
 install(TARGETS
-        example_global_navigation_cpp
+        example_global_navigation
         DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)

--- a/examples/cpp/navigation/local_navigation/CMakeLists.txt
+++ b/examples/cpp/navigation/local_navigation/CMakeLists.txt
@@ -18,12 +18,12 @@ find_package(rclcpp REQUIRED)
 find_package(px4_ros2_cpp REQUIRED)
 
 include_directories(include ${Eigen3_INCLUDE_DIRS})
-add_executable(example_local_navigation_cpp
+add_executable(example_local_navigation
         src/main.cpp)
-ament_target_dependencies(example_local_navigation_cpp Eigen3 px4_ros2_cpp rclcpp)
+ament_target_dependencies(example_local_navigation Eigen3 px4_ros2_cpp rclcpp)
 
 install(TARGETS
-        example_local_navigation_cpp
+        example_local_navigation
         DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)


### PR DESCRIPTION
Renames executables to reflect the naming used in the mode examples.

### Previous usage:
```
ros2 run example_global_navigation_cpp example_global_navigation_cpp
```

### New usage:
```
ros2 run example_global_navigation_cpp example_global_navigation
```

I'm updating the px4 user guide to reflect this change.