### PR TITLE
Generic subscriptions

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/odometry/global_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/global_position.hpp
@@ -10,8 +10,6 @@
 #include <px4_ros2/common/context.hpp>
 #include <px4_ros2/odometry/subscription.hpp>
 
-using namespace std::chrono_literals; // NOLINT
-
 namespace px4_ros2
 {
 /** \ingroup odometry
@@ -21,27 +19,16 @@ namespace px4_ros2
 /**
  * Provides access to the vehicle's global position estimate
  */
-class OdometryGlobalPosition
+class OdometryGlobalPosition : public Subscription<px4_msgs::msg::VehicleGlobalPosition>
 {
 public:
   explicit OdometryGlobalPosition(Context & context);
 
-  bool valid()
-  {
-    return _node.get_clock()->now() - _last_vehicle_global_position < 500ms;
-  }
-
   Eigen::Vector3d position() const
   {
-    return {_vehicle_global_position.lat, _vehicle_global_position.lon,
-      _vehicle_global_position.alt};
+    const px4_msgs::msg::VehicleGlobalPosition pos = last();
+    return {pos.lat, pos.lon, pos.alt};
   }
-
-private:
-  rclcpp::Node & _node;
-  Subscription<px4_msgs::msg::VehicleGlobalPosition> _vehicle_global_position_sub;
-  px4_msgs::msg::VehicleGlobalPosition _vehicle_global_position;
-  rclcpp::Time _last_vehicle_global_position;
 };
 
 /** @}*/

--- a/px4_ros2_cpp/include/px4_ros2/odometry/global_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/global_position.hpp
@@ -5,11 +5,10 @@
 
 #pragma once
 
-#include <px4_msgs/msg/vehicle_global_position.hpp>
-#include <rclcpp/rclcpp.hpp>
 #include <Eigen/Eigen>
+#include <px4_msgs/msg/vehicle_global_position.hpp>
 #include <px4_ros2/common/context.hpp>
-
+#include <px4_ros2/odometry/subscription.hpp>
 
 using namespace std::chrono_literals; // NOLINT
 
@@ -40,7 +39,7 @@ public:
 
 private:
   rclcpp::Node & _node;
-  rclcpp::Subscription<px4_msgs::msg::VehicleGlobalPosition>::SharedPtr _vehicle_global_position_sub;
+  Subscription<px4_msgs::msg::VehicleGlobalPosition> _vehicle_global_position_sub;
   px4_msgs::msg::VehicleGlobalPosition _vehicle_global_position;
   rclcpp::Time _last_vehicle_global_position;
 };

--- a/px4_ros2_cpp/include/px4_ros2/odometry/global_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/global_position.hpp
@@ -24,9 +24,14 @@ class OdometryGlobalPosition : public Subscription<px4_msgs::msg::VehicleGlobalP
 public:
   explicit OdometryGlobalPosition(Context & context);
 
+  /**
+   * @brief Get the vehicle's global position.
+   *
+   * @returns a vector of (latitude [°], longitude [°], altitude [m AMSL])
+   */
   Eigen::Vector3d position() const
   {
-    const px4_msgs::msg::VehicleGlobalPosition pos = last();
+    const px4_msgs::msg::VehicleGlobalPosition & pos = last();
     return {pos.lat, pos.lon, pos.alt};
   }
 };

--- a/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
@@ -26,38 +26,38 @@ public:
 
   bool positionXYValid() const
   {
-    return last().xy_valid;
+    return lastValid() && last().xy_valid;
   }
 
   bool positionZValid() const
   {
-    return last().z_valid;
+    return lastValid() && last().z_valid;
   }
 
-  Eigen::Vector3f position() const
+  Eigen::Vector3f positionNed() const
   {
-    const px4_msgs::msg::VehicleLocalPosition pos = last();
+    const px4_msgs::msg::VehicleLocalPosition & pos = last();
     return {pos.x, pos.y, pos.z};
   }
 
   bool velocityXYValid() const
   {
-    return last().v_xy_valid;
+    return lastValid() && last().v_xy_valid;
   }
 
   bool velocityZValid() const
   {
-    return last().v_z_valid;
+    return lastValid() && last().v_z_valid;
   }
-  Eigen::Vector3f velocity() const
+  Eigen::Vector3f velocityNed() const
   {
-    const px4_msgs::msg::VehicleLocalPosition pos = last();
+    const px4_msgs::msg::VehicleLocalPosition & pos = last();
     return {pos.vx, pos.vy, pos.vz};
   }
 
-  Eigen::Vector3f acceleration() const
+  Eigen::Vector3f accelerationNed() const
   {
-    const px4_msgs::msg::VehicleLocalPosition pos = last();
+    const px4_msgs::msg::VehicleLocalPosition & pos = last();
     return {pos.ax, pos.ay, pos.az};
   }
 };

--- a/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
@@ -9,6 +9,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <Eigen/Eigen>
 #include <px4_ros2/common/context.hpp>
+#include <px4_ros2/odometry/subscription.hpp>
 
 
 namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
@@ -19,48 +19,47 @@ namespace px4_ros2
 /**
  * Provides access to the vehicle's local position estimate
  */
-class OdometryLocalPosition
+class OdometryLocalPosition : public Subscription<px4_msgs::msg::VehicleLocalPosition>
 {
 public:
   explicit OdometryLocalPosition(Context & context);
 
-  bool positionXyValid() const
+  bool positionXYValid() const
   {
-    return _vehicle_local_position.xy_valid;
+    return last().xy_valid;
   }
 
   bool positionZValid() const
   {
-    return _vehicle_local_position.z_valid;
+    return last().z_valid;
   }
 
   Eigen::Vector3f position() const
   {
-    return {_vehicle_local_position.x, _vehicle_local_position.y, _vehicle_local_position.z};
+    const px4_msgs::msg::VehicleLocalPosition pos = last();
+    return {pos.x, pos.y, pos.z};
   }
 
   bool velocityXYValid() const
   {
-    return _vehicle_local_position.v_xy_valid;
+    return last().v_xy_valid;
   }
 
   bool velocityZValid() const
   {
-    return _vehicle_local_position.v_z_valid;
+    return last().v_z_valid;
   }
   Eigen::Vector3f velocity() const
   {
-    return {_vehicle_local_position.vx, _vehicle_local_position.vy, _vehicle_local_position.vz};
+    const px4_msgs::msg::VehicleLocalPosition pos = last();
+    return {pos.vx, pos.vy, pos.vz};
   }
 
   Eigen::Vector3f acceleration() const
   {
-    return {_vehicle_local_position.ax, _vehicle_local_position.ay, _vehicle_local_position.az};
+    const px4_msgs::msg::VehicleLocalPosition pos = last();
+    return {pos.ax, pos.ay, pos.az};
   }
-
-private:
-  Subscription<px4_msgs::msg::VehicleLocalPosition> _vehicle_local_position_sub;
-  px4_msgs::msg::VehicleLocalPosition _vehicle_local_position;
 };
 
 /** @}*/

--- a/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
@@ -5,12 +5,10 @@
 
 #pragma once
 
-#include <px4_msgs/msg/vehicle_local_position.hpp>
-#include <rclcpp/rclcpp.hpp>
 #include <Eigen/Eigen>
+#include <px4_msgs/msg/vehicle_local_position.hpp>
 #include <px4_ros2/common/context.hpp>
 #include <px4_ros2/odometry/subscription.hpp>
-
 
 namespace px4_ros2
 {
@@ -61,7 +59,7 @@ public:
   }
 
 private:
-  rclcpp::Subscription<px4_msgs::msg::VehicleLocalPosition>::SharedPtr _vehicle_local_position_sub;
+  Subscription<px4_msgs::msg::VehicleLocalPosition> _vehicle_local_position_sub;
   px4_msgs::msg::VehicleLocalPosition _vehicle_local_position;
 };
 

--- a/px4_ros2_cpp/include/px4_ros2/odometry/subscription.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/subscription.hpp
@@ -7,28 +7,51 @@
 
 #include <px4_ros2/common/context.hpp>
 
-namespace px4_ros2 {
+namespace px4_ros2
+{
+/** \ingroup odometry
+ *  @{
+ */
 
-template <typename RosMessageType> class Subscription {
+/**
+ * Provides a subscription to arbitrary ROS topics.
+ */
+template<typename RosMessageType>
+class Subscription
+{
 public:
-  Subscription(Context &context, const std::string &topic)
-      : _node(context.node()), _topic(context.topicNamespacePrefix() + topic) {
+  Subscription(Context & context, const std::string & topic)
+  : _node(context.node()), _topic(context.topicNamespacePrefix() + topic)
+  {
     _subscription = _node.create_subscription<RosMessageType>(
-        _topic, rclcpp::QoS(1).best_effort(),
-        [this](const typename RosMessageType::UniquePtr msg) {
-          _last = *msg;
-          _last_message_time = _node.get_clock()->now();
-          for (const auto& callback : _callbacks) {
-            callback(_last);
-          }
-        });
+      _topic, rclcpp::QoS(1).best_effort(),
+      [this](const typename RosMessageType::UniquePtr msg) {
+        _last = *msg;
+        _last_message_time = _node.get_clock()->now();
+        for (const auto & callback : _callbacks) {
+          callback(_last);
+        }
+      });
   }
 
-  void subscribe(std::function<void(RosMessageType)> callback) {
+  /**
+   * @brief Register a callback to be executed for each message.
+   *
+   * @param callback the callback function
+   */
+  void subscribe(std::function<void(RosMessageType)> callback)
+  {
     _callbacks.push_back(callback);
   }
 
-  RosMessageType last() const {
+  /**
+   * @brief Get the last-received message.
+   *
+   * @returns the last-received ROS message
+   * @throws std::runtime_error when no messages have been received
+   */
+  RosMessageType last() const
+  {
     if (_last_message_time.seconds() == 0) {
       throw std::runtime_error("No messages received.");
     }
@@ -36,11 +59,10 @@ public:
   }
 
 private:
-  rclcpp::Node &_node;
+  rclcpp::Node & _node;
   std::string _topic;
 
-  typename rclcpp::Subscription<RosMessageType>::SharedPtr _subscription{
-      nullptr};
+  typename rclcpp::Subscription<RosMessageType>::SharedPtr _subscription{nullptr};
 
   RosMessageType _last;
   rclcpp::Time _last_message_time;
@@ -48,4 +70,5 @@ private:
   std::vector<std::function<void(RosMessageType)>> _callbacks{};
 };
 
+/** @}*/
 } // namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/odometry/subscription.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/subscription.hpp
@@ -1,0 +1,51 @@
+/****************************************************************************
+ * Copyright (c) 2023 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#pragma once
+
+#include <px4_ros2/common/context.hpp>
+
+namespace px4_ros2 {
+
+template <typename RosMessageType> class Subscription {
+public:
+  Subscription(Context &context, const std::string &topic)
+      : _node(context.node()), _topic(context.topicNamespacePrefix() + topic) {
+    _subscription = _node.create_subscription<RosMessageType>(
+        _topic, rclcpp::QoS(1).best_effort(),
+        [this](const typename RosMessageType::UniquePtr msg) {
+          _last = *msg;
+          _last_message_time = _node.get_clock()->now();
+          for (const auto& callback : _callbacks) {
+            callback(_last);
+          }
+        });
+  }
+
+  void subscribe(std::function<void(RosMessageType)> callback) {
+    _callbacks.push_back(callback);
+  }
+
+  RosMessageType last() const {
+    if (_last_message_time.seconds() == 0) {
+      throw std::runtime_error("No messages received.");
+    }
+    return _last;
+  }
+
+private:
+  rclcpp::Node &_node;
+  std::string _topic;
+
+  typename rclcpp::Subscription<RosMessageType>::SharedPtr _subscription{
+      nullptr};
+
+  RosMessageType _last;
+  rclcpp::Time _last_message_time;
+
+  std::vector<std::function<void(RosMessageType)>> _callbacks{};
+};
+
+} // namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/odometry/subscription.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/subscription.hpp
@@ -57,7 +57,7 @@ public:
    */
   const RosMessageType & last() const
   {
-    if (_last_message_time.seconds() == 0) {
+    if (!hasReceivedMessages()) {
       throw std::runtime_error("No messages received.");
     }
     return _last;
@@ -83,7 +83,7 @@ public:
   template<typename DurationT = std::milli>
   bool lastValid(const std::chrono::duration<int64_t, DurationT> max_delay = 500ms) const
   {
-    return _node.get_clock()->now() - _last_message_time < max_delay;
+    return hasReceivedMessages() && _node.get_clock()->now() - _last_message_time < max_delay;
   }
 
 private:
@@ -95,6 +95,11 @@ private:
   rclcpp::Time _last_message_time;
 
   std::vector<std::function<void(const RosMessageType &)>> _callbacks{};
+
+  bool hasReceivedMessages() const
+  {
+    return _last_message_time.seconds() != 0;
+  }
 };
 
 /** @}*/

--- a/px4_ros2_cpp/include/px4_ros2/odometry/subscription.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/subscription.hpp
@@ -21,6 +21,8 @@ namespace px4_ros2
 template<typename RosMessageType>
 class Subscription
 {
+  using UpdateCallback = std::function<void (const RosMessageType &)>;
+
 public:
   Subscription(Context & context, const std::string & topic)
   : _node(context.node())
@@ -42,7 +44,7 @@ public:
    *
    * @param callback the callback function
    */
-  void onUpdate(std::function<void(RosMessageType)> callback)
+  void onUpdate(const UpdateCallback & callback)
   {
     _callbacks.push_back(callback);
   }

--- a/px4_ros2_cpp/src/odometry/global_position.cpp
+++ b/px4_ros2_cpp/src/odometry/global_position.cpp
@@ -5,20 +5,17 @@
 
 #include <px4_ros2/odometry/global_position.hpp>
 
-
 namespace px4_ros2
 {
 
 OdometryGlobalPosition::OdometryGlobalPosition(Context & context)
 : _node(context.node()),
+  _vehicle_global_position_sub(context, "/fmu/out/vehicle_global_position"),
   _last_vehicle_global_position(_node.get_clock()->now() - 1s)
 {
-  _vehicle_global_position_sub =
-    context.node().create_subscription<px4_msgs::msg::VehicleGlobalPosition>(
-    context.topicNamespacePrefix() + "/fmu/out/vehicle_global_position", rclcpp::QoS(
-      1).best_effort(),
-    [this, context](px4_msgs::msg::VehicleGlobalPosition::UniquePtr msg) {
-      _vehicle_global_position = *msg;
+  _vehicle_global_position_sub.subscribe(
+    [this](const px4_msgs::msg::VehicleGlobalPosition msg) {
+      _vehicle_global_position = msg;
       _last_vehicle_global_position = _node.get_clock()->now();
     });
 
@@ -26,4 +23,5 @@ OdometryGlobalPosition::OdometryGlobalPosition(Context & context)
   requirements.global_position = true;
   context.setRequirement(requirements);
 }
+
 } // namespace px4_ros2

--- a/px4_ros2_cpp/src/odometry/global_position.cpp
+++ b/px4_ros2_cpp/src/odometry/global_position.cpp
@@ -9,16 +9,8 @@ namespace px4_ros2
 {
 
 OdometryGlobalPosition::OdometryGlobalPosition(Context & context)
-: _node(context.node()),
-  _vehicle_global_position_sub(context, "/fmu/out/vehicle_global_position"),
-  _last_vehicle_global_position(_node.get_clock()->now() - 1s)
+: Subscription<px4_msgs::msg::VehicleGlobalPosition>(context, "/fmu/out/vehicle_global_position")
 {
-  _vehicle_global_position_sub.subscribe(
-    [this](const px4_msgs::msg::VehicleGlobalPosition msg) {
-      _vehicle_global_position = msg;
-      _last_vehicle_global_position = _node.get_clock()->now();
-    });
-
   RequirementFlags requirements{};
   requirements.global_position = true;
   context.setRequirement(requirements);

--- a/px4_ros2_cpp/src/odometry/local_position.cpp
+++ b/px4_ros2_cpp/src/odometry/local_position.cpp
@@ -5,18 +5,15 @@
 
 #include <px4_ros2/odometry/local_position.hpp>
 
-
 namespace px4_ros2
 {
 
 OdometryLocalPosition::OdometryLocalPosition(Context & context)
+: _vehicle_local_position_sub(context, "/fmu/out/vehicle_local_position")
 {
-  _vehicle_local_position_sub =
-    context.node().create_subscription<px4_msgs::msg::VehicleLocalPosition>(
-    context.topicNamespacePrefix() + "/fmu/out/vehicle_local_position", rclcpp::QoS(
-      1).best_effort(),
-    [this](px4_msgs::msg::VehicleLocalPosition::UniquePtr msg) {
-      _vehicle_local_position = *msg;
+  _vehicle_local_position_sub.subscribe(
+    [this](const px4_msgs::msg::VehicleLocalPosition msg) {
+      _vehicle_local_position = msg;
     });
 
   RequirementFlags requirements{};
@@ -24,4 +21,5 @@ OdometryLocalPosition::OdometryLocalPosition(Context & context)
   requirements.local_alt = true;
   context.setRequirement(requirements);
 }
+
 } // namespace px4_ros2

--- a/px4_ros2_cpp/src/odometry/local_position.cpp
+++ b/px4_ros2_cpp/src/odometry/local_position.cpp
@@ -9,13 +9,8 @@ namespace px4_ros2
 {
 
 OdometryLocalPosition::OdometryLocalPosition(Context & context)
-: _vehicle_local_position_sub(context, "/fmu/out/vehicle_local_position")
+: Subscription<px4_msgs::msg::VehicleLocalPosition>(context, "/fmu/out/vehicle_local_position")
 {
-  _vehicle_local_position_sub.subscribe(
-    [this](const px4_msgs::msg::VehicleLocalPosition msg) {
-      _vehicle_local_position = msg;
-    });
-
   RequirementFlags requirements{};
   requirements.local_position = true;
   requirements.local_alt = true;


### PR DESCRIPTION
Allows adding subscriptions to arbitrary ROS topics.
Users can register (multiple) callbacks or simply poll the last-received message.


### Example usage

```cpp
px4_ros2::Subscription<px4_msgs::msg::VehicleLocalPosition> ros_sub(context, "/fmu/out/vehicle_local_position");

// Create callback
ros_sub.onUpdate([](px4_msgs::msg::VehicleLocalPosition msg) {
    std::cout << "Local pos from callback: " << msg.x << " " << msg.y << " " << msg.z << std::endl;
});

// Poll latest message
px4_msgs::msg::VehicleLocalPosition msg = ros_sub.last();
std::cout << "Local pos latest: " << msg.x << " " << msg.y << " " << msg.z << std::endl;
```