### PR TITLE
Add geometry and conversion utils

### DIFF
--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -43,6 +43,8 @@ set(HEADER_FILES
         include/px4_ros2/navigation/experimental/navigation_interface_base.hpp
         include/px4_ros2/odometry/global_position.hpp
         include/px4_ros2/odometry/local_position.hpp
+        include/px4_ros2/utils/frame_conversion.hpp
+        include/px4_ros2/utils/geometry.hpp
 )
 
 add_library(px4_ros2_cpp
@@ -115,14 +117,22 @@ if(BUILD_TESTING)
 
 
     # Unit tests
+    add_library(unit_utils
+            test/unit/utils/util.cpp
+    )
+    include_directories(include)
+    ament_target_dependencies(unit_utils Eigen3)
+
     ament_add_gtest(${PROJECT_NAME}_unit_tests
             test/unit/global_navigation.cpp
             test/unit/local_navigation.cpp
             test/unit/main.cpp
             test/unit/modes.cpp
+            test/unit/utils/frame_conversion.cpp
+            test/unit/utils/geometry.cpp
     )
     target_include_directories(${PROJECT_NAME}_unit_tests PRIVATE ${CMAKE_CURRENT_LIST_DIR})
-    target_link_libraries(${PROJECT_NAME}_unit_tests ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}_unit_tests ${PROJECT_NAME} unit_utils)
     ament_target_dependencies(${PROJECT_NAME}_unit_tests
             rclcpp px4_msgs
     )

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/attitude.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/attitude.hpp
@@ -28,7 +28,7 @@ public:
 
   void update(
     const Eigen::Quaternionf & attidude_setpoint,
-    const Eigen::Vector3f & thrust_setpoint_ned, float yaw_sp_move_rate_rad_s = 0.F);
+    const Eigen::Vector3f & thrust_setpoint_frd, float yaw_sp_move_rate_rad_s = 0.F);
 
 private:
   rclcpp::Node & _node;

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/rates.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/rates.hpp
@@ -28,7 +28,7 @@ public:
 
   void update(
     const Eigen::Vector3f & rate_setpoints_ned_rad,
-    const Eigen::Vector3f & thrust_setpoint_ned);
+    const Eigen::Vector3f & thrust_setpoint_frd);
 
 private:
   rclcpp::Node & _node;

--- a/px4_ros2_cpp/include/px4_ros2/utils/frame_conversion.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/frame_conversion.hpp
@@ -1,0 +1,179 @@
+/****************************************************************************
+ * Copyright (c) 2024 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#pragma once
+
+#include <Eigen/Eigen>
+#include <px4_ros2/utils/geometry.hpp>
+
+namespace px4_ros2
+{
+
+/**
+ * @brief Converts attitude from NED to ENU frame.
+ * Performs reference frame change and quaternion rotation s.t. the identity quaternion points along the x-axis within its reference frame.
+ *
+ * @param q_ned Attitude quaternion in NED frame.
+ * @return Attitude quaternion in ENU frame.
+ */
+template<typename Type>
+Eigen::Quaternion<Type> attitudeNedToEnu(const Eigen::Quaternion<Type> & q_ned)
+{
+  static constexpr Type kHalfSqrt2 = static_cast<Type>(0.7071067811865476);
+  const Eigen::Quaternion<Type> q_ned_to_enu {0.0, kHalfSqrt2, kHalfSqrt2, 0.0};  // 180 deg along X, -90 deg along Z
+  const Eigen::Quaternion<Type> q_yaw_minus_pi_2{kHalfSqrt2, 0.0, 0.0, -kHalfSqrt2};  // -90 deg along Z
+
+  return q_ned_to_enu * q_ned * q_yaw_minus_pi_2 * q_ned_to_enu.inverse();
+}
+
+/**
+ * @brief Converts attitude from ENU to NED frame.
+ * Performs reference frame change and quaternion rotation s.t. the identity quaternion points along the x-axis within its reference frame.
+ *
+ * @param q_enu Attitude quaternion in ENU frame.
+ * @return Attitude quaternion in NED frame.
+ */
+template<typename Type>
+Eigen::Quaternion<Type> attitudeEnuToNed(const Eigen::Quaternion<Type> & q_enu)
+{
+  static constexpr Type kHalfSqrt2 = static_cast<Type>(0.7071067811865476);
+  const Eigen::Quaternion<Type> q_enu_to_ned {0.0, kHalfSqrt2, kHalfSqrt2, 0.0};  // 180 deg along X, -90 deg along Z
+  const Eigen::Quaternion<Type> q_yaw_minus_pi_2{kHalfSqrt2, 0.0, 0.0, -kHalfSqrt2};  // -90 deg along Z
+
+  return q_enu_to_ned * q_enu * q_yaw_minus_pi_2 * q_enu_to_ned.inverse();
+}
+
+/**
+ * @brief Transforms a point from body frame to world frame given the yaw of the body's attitude.
+ *
+ * @param yaw The yaw of the body's attitude [rad].
+ * @param point_body The point coordinates in the body frame.
+ * @return The yaw rotated point in the world frame.
+ */
+template<typename Type>
+Eigen::Matrix<Type, 3, 1> yawBodyToWorld(
+  Type yaw,
+  const Eigen::Matrix<Type, 3, 1> & point_body)
+{
+  const Eigen::Quaternion<Type> q_z(Eigen::AngleAxis<Type>(
+      yaw, Eigen::Matrix<Type, 3, 1>::UnitZ()));
+  return q_z * point_body;
+}
+
+/**
+ * @brief Converts yaw from NED to ENU frame.
+ *
+ * @param yaw_ned_rad Yaw angle in NED frame [rad].
+ * @return Yaw angle in ENU frame [rad], wrapped to [-pi, pi].
+ */
+template<typename T>
+static inline T yawNedToEnu(const T yaw_ned_rad)
+{
+  return wrapPi(static_cast<T>(M_PI / 2.0) - yaw_ned_rad);
+}
+
+/**
+ * @brief Converts yaw from ENU to NED frame.
+ *
+ * @param yaw_enu_rad Yaw angle in ENU frame [rad].
+ * @return Yaw angle in NED frame [rad], wrapped to [-pi, pi].
+ */
+template<typename T>
+static inline T yawEnuToNed(const T yaw_enu_rad)
+{
+  return wrapPi(static_cast<T>(M_PI / 2.0) - yaw_enu_rad);
+}
+
+/**
+ * @brief Converts yaw rate from NED to ENU frame.
+ *
+ * @param yaw_rate_ned Yaw rate in NED frame.
+ * @return Yaw rate in ENU frame.
+ */
+template<typename T>
+static inline T yawRateNedToEnu(const T yaw_rate_ned) {return -yaw_rate_ned;}
+
+/**
+ * @brief Converts yaw rate from ENU to NED frame.
+ *
+ * @param yaw_rate_enu Yaw rate in ENU frame.
+ * @return Yaw rate in NED frame.
+ */
+template<typename T>
+static inline T yawRateEnuToNed(const T yaw_rate_enu) {return -yaw_rate_enu;}
+
+/**
+ * @brief Converts coordinates from NED to ENU frame.
+ *
+ * @param ned Coordinates in NED frame.
+ * @return Coordinates in ENU frame.
+ */
+template<typename T>
+static inline Eigen::Matrix<T, 3, 1> positionNedToEnu(const Eigen::Matrix<T, 3, 1> & ned)
+{
+  return {ned.y(), ned.x(), -ned.z()};
+}
+
+/**
+ * @brief Converts coordinates from ENU to NED frame.
+ *
+ * @param enu Coordinates in ENU frame.
+ * @return Coordinates in NED frame.
+ */
+template<typename T>
+static inline Eigen::Matrix<T, 3, 1> positionEnuToNed(const Eigen::Matrix<T, 3, 1> & enu)
+{
+  return {enu.y(), enu.x(), -enu.z()};
+}
+
+/**
+ * @brief Converts coordinates from FRD to FLU frame.
+ *
+ * @param frd Coordinates in FRD frame.
+ * @return Coordinates in FLU frame.
+ */
+template<typename T>
+static inline Eigen::Matrix<T, 3, 1> frdToFlu(const Eigen::Matrix<T, 3, 1> & frd)
+{
+  return {frd.x(), -frd.y(), -frd.z()};
+}
+
+/**
+ * @brief Converts coordinates from FLU to FRD frame.
+ *
+ * @param flu Coordinates in FLU frame.
+ * @return Coordinates in FRD frame.
+ */
+template<typename T>
+static inline Eigen::Matrix<T, 3, 1> fluToFrd(const Eigen::Matrix<T, 3, 1> & flu)
+{
+  return {flu.x(), -flu.y(), -flu.z()};
+}
+
+/**
+ * @brief Converts variance from NED to ENU frame.
+ *
+ * @param v_ned Variance vector in NED frame.
+ * @return Variance vector in ENU frame.
+ */
+template<typename T>
+static inline Eigen::Matrix<T, 3, 1> varianceNedToEnu(const Eigen::Matrix<T, 3, 1> & v_ned)
+{
+  return {v_ned.y(), v_ned.x(), v_ned.z()};
+}
+
+/**
+ * @brief Converts variance from ENU to NED frame.
+ *
+ * @param v_enu Variance vector in ENU frame.
+ * @return Variance vector in NED frame.
+ */
+template<typename T>
+static inline Eigen::Matrix<T, 3, 1> varianceEnuToNed(const Eigen::Matrix<T, 3, 1> & v_enu)
+{
+  return {v_enu.y(), v_enu.x(), v_enu.z()};
+}
+
+}  // namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/utils/geometry.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/geometry.hpp
@@ -1,0 +1,110 @@
+/****************************************************************************
+ * Copyright (c) 2024 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#pragma once
+
+#include <Eigen/Eigen>
+
+namespace px4_ros2
+{
+
+/**
+ * @brief Wraps an angle to the range [-pi, pi).
+ *
+ * @param angle The input angle [rad].
+ * @return The wrapped angle in the range [-pi, pi).
+ */
+template<typename Type>
+Type wrapPi(Type angle)
+{
+  while (angle >= M_PI) {
+    angle -= 2.0 * M_PI;
+  }
+  while (angle < -M_PI) {
+    angle += 2.0 * M_PI;
+  }
+  return angle;
+}
+
+/**
+ * @brief Converts a quaternion to Euler angles.
+ *
+ * @param q The input quaternion.
+ * @return Euler angles (order: RPY) corresponding to the given quaternion in range r, p, y = [-pi, pi], [-pi/2, pi], [-pi, pi].
+ */
+template<typename Type>
+Eigen::Matrix<Type, 3, 1> quaternionToEulerRPY(const Eigen::Quaternion<Type> & q)
+{
+  Eigen::Matrix<Type, 3, 1> angles;
+  Eigen::Matrix<Type, 3, 3> dcm = q.toRotationMatrix();
+
+  angles.y() = asin(-dcm.coeff(2, 0));
+
+  if ((std::fabs(angles.y() - static_cast<Type>(M_PI / 2))) < static_cast<Type>(1.0e-3)) {
+    angles.x() = 0;
+    angles.z() = atan2(dcm.coeff(1, 2), dcm.coeff(0, 2));
+  } else if ((std::fabs(angles.y() + static_cast<Type>(M_PI / 2))) < static_cast<Type>(1.0e-3)) {
+    angles.x() = 0;
+    angles.z() = atan2(-dcm.coeff(1, 2), -dcm.coeff(0, 2));
+  } else {
+    angles.x() = atan2(dcm.coeff(2, 1), dcm.coeff(2, 2));
+    angles.z() = atan2(dcm.coeff(1, 0), dcm.coeff(0, 0));
+  }
+
+  return angles;
+}
+
+/**
+ * @brief Convert quaternion to roll angle;
+ *
+ * @param q The input quaternion
+ * @return Roll angle (order: RPY) corresponding to the given quaternion in range [-pi, pi]
+*/
+template<typename Type>
+Type quaternionToRoll(const Eigen::Quaternion<Type> & q)
+{
+  Type x = q.x();
+  Type y = q.y();
+  Type z = q.z();
+  Type w = q.w();
+
+  return std::atan2(2.0 * (w * x + y * z), w * w - x * x - y * y + z * z);
+}
+
+/**
+ * @brief Convert quaternion to pitch angle;
+ *
+ * @param q The input quaternion
+ * @return Pitch angle (order: RPY) corresponding to the given quaternion in range [-pi, pi]
+*/
+template<typename Type>
+Type quaternionToPitch(const Eigen::Quaternion<Type> & q)
+{
+  Type x = q.x();
+  Type y = q.y();
+  Type z = q.z();
+  Type w = q.w();
+
+  return std::atan2(2.0 * (w * y - z * x), 1.0 - 2.0 * (x * x + y * y));
+}
+
+/**
+ * @brief Convert quaternion to yaw angle;
+ *
+ * @param q The input quaternion
+ * @return Yaw angle (order: RPY) corresponding to the given quaternion in range [-pi, pi]
+*/
+template<typename Type>
+Type quaternionToYaw(const Eigen::Quaternion<Type> & q)
+{
+  Type x = q.x();
+  Type y = q.y();
+  Type z = q.z();
+  Type w = q.w();
+
+  return std::atan2(2.0 * (x * y + w * z), w * w + x * x - y * y - z * z);
+}
+
+}  // namespace px4_ros2

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/attitude.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/attitude.cpp
@@ -19,7 +19,7 @@ AttitudeSetpointType::AttitudeSetpointType(Context & context)
 
 void AttitudeSetpointType::update(
   const Eigen::Quaternionf & attidude_setpoint,
-  const Eigen::Vector3f & thrust_setpoint_ned,
+  const Eigen::Vector3f & thrust_setpoint_frd,
   float yaw_sp_move_rate_rad_s)
 {
   onUpdate();
@@ -29,9 +29,9 @@ void AttitudeSetpointType::update(
   sp.q_d[1] = attidude_setpoint.x();
   sp.q_d[2] = attidude_setpoint.y();
   sp.q_d[3] = attidude_setpoint.z();
-  sp.thrust_body[0] = thrust_setpoint_ned(0);
-  sp.thrust_body[1] = thrust_setpoint_ned(1);
-  sp.thrust_body[2] = thrust_setpoint_ned(2);
+  sp.thrust_body[0] = thrust_setpoint_frd(0);
+  sp.thrust_body[1] = thrust_setpoint_frd(1);
+  sp.thrust_body[2] = thrust_setpoint_frd(2);
   sp.yaw_sp_move_rate = yaw_sp_move_rate_rad_s;
   sp.timestamp = _node.get_clock()->now().nanoseconds() / 1000;
   _vehicle_attitude_setpoint_pub->publish(sp);

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/rates.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/rates.cpp
@@ -19,7 +19,7 @@ RatesSetpointType::RatesSetpointType(Context & context)
 
 void RatesSetpointType::update(
   const Eigen::Vector3f & rate_setpoints_ned_rad,
-  const Eigen::Vector3f & thrust_setpoint_ned)
+  const Eigen::Vector3f & thrust_setpoint_frd)
 {
   onUpdate();
 
@@ -27,9 +27,9 @@ void RatesSetpointType::update(
   sp.roll = rate_setpoints_ned_rad(0);
   sp.pitch = rate_setpoints_ned_rad(1);
   sp.yaw = rate_setpoints_ned_rad(2);
-  sp.thrust_body[0] = thrust_setpoint_ned(0);
-  sp.thrust_body[1] = thrust_setpoint_ned(1);
-  sp.thrust_body[2] = thrust_setpoint_ned(2);
+  sp.thrust_body[0] = thrust_setpoint_frd(0);
+  sp.thrust_body[1] = thrust_setpoint_frd(1);
+  sp.thrust_body[2] = thrust_setpoint_frd(2);
   sp.timestamp = _node.get_clock()->now().nanoseconds() / 1000;
   _vehicle_rates_setpoint_pub->publish(sp);
 }

--- a/px4_ros2_cpp/test/unit/utils/frame_conversion.cpp
+++ b/px4_ros2_cpp/test/unit/utils/frame_conversion.cpp
@@ -1,0 +1,249 @@
+/****************************************************************************
+ * Copyright (c) 2024 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#include "util.hpp"
+
+#include <gtest/gtest.h>
+#include <px4_ros2/utils/frame_conversion.hpp>
+
+
+TEST(FrameConversion, yawNedToEnu) {
+  EXPECT_FLOAT_EQ(M_PI_2, px4_ros2::yawNedToEnu(0.F));
+  EXPECT_FLOAT_EQ(M_PI / 4.F, px4_ros2::yawNedToEnu(M_PI / 4.F));
+  EXPECT_FLOAT_EQ(-M_PI_2, px4_ros2::yawNedToEnu(M_PI));
+  EXPECT_FLOAT_EQ(M_PI, std::fabs(px4_ros2::yawNedToEnu(-M_PI_2)));
+}
+
+TEST(FrameConversion, yawEnuToNed) {
+  EXPECT_FLOAT_EQ(M_PI_2, px4_ros2::yawEnuToNed(0.F));
+  EXPECT_FLOAT_EQ(M_PI / 4.F, px4_ros2::yawEnuToNed(M_PI / 4.F));
+  EXPECT_FLOAT_EQ(-M_PI_2, px4_ros2::yawEnuToNed(M_PI));
+  EXPECT_FLOAT_EQ(M_PI, std::fabs(px4_ros2::yawEnuToNed(-M_PI_2)));
+}
+
+TEST(FrameConversion, yawRateNedToEnu) {
+  EXPECT_FLOAT_EQ(0.F, px4_ros2::yawRateNedToEnu(0.F));
+  EXPECT_FLOAT_EQ(12.3F, px4_ros2::yawRateNedToEnu(-12.3F));
+}
+
+TEST(FrameConversion, yawRateEnuToNed) {
+  EXPECT_FLOAT_EQ(0.F, px4_ros2::yawRateEnuToNed(0.F));
+  EXPECT_FLOAT_EQ(12.3F, px4_ros2::yawRateEnuToNed(-12.3F));
+}
+
+TEST(FrameConversion, attitudeNedToEnu) {
+  Eigen::Quaternionf q_ned;
+  Eigen::Quaternionf q_enu;
+
+  // North
+  q_ned = Eigen::Quaternionf::Identity();
+  q_enu = Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
+
+  // Test various multi-axis rotations
+  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
+
+  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI - 0.1F, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-M_PI + 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
+
+  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI + 0.1F, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-M_PI - 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
+
+  q_ned = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
+
+  q_ned = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
+
+  q_ned = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-M_PI + 0.1F, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(M_PI - 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
+
+  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-M_PI - 0.1F, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(M_PI + 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
+
+  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
+}
+
+TEST(FrameConversion, attitudeEnuToNed) {
+  Eigen::Quaternionf q_ned;
+  Eigen::Quaternionf q_enu;
+
+  // East
+  q_enu = Eigen::Quaternionf::Identity();
+  q_ned = Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeEnuToNed(q_ned));
+
+  // Test various multi-axis rotations
+  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
+
+  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI - 0.1F, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-M_PI + 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
+
+  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI + 0.1F, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-M_PI - 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
+
+  q_enu = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
+
+  q_enu = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
+
+  q_enu = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-M_PI + 0.1F, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(M_PI - 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
+
+  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-M_PI - 0.1F, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(M_PI + 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
+
+  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
+}
+
+TEST(FrameConversion, positionNedToEnu) {
+  Eigen::Vector3f v_ned(1.F, 2.F, 3.F);
+  Eigen::Vector3f v_enu(2.F, 1.F, -3.F);
+  vectorsApproxEqualTest(v_enu, px4_ros2::positionNedToEnu(v_ned));
+}
+
+TEST(FrameConversion, positionEnuToNed) {
+  Eigen::Vector3f v_enu(1.F, 2.F, 3.F);
+  Eigen::Vector3f v_ned(2.F, 1.F, -3.F);
+  vectorsApproxEqualTest(v_ned, px4_ros2::positionEnuToNed(v_enu));
+}
+
+TEST(FrameConversion, frdToFlu) {
+  Eigen::Vector3f v_frd(1.F, 2.F, 3.F);
+  Eigen::Vector3f v_flu(1.F, -2.F, -3.F);
+  vectorsApproxEqualTest(v_flu, px4_ros2::frdToFlu(v_frd));
+}
+
+TEST(FrameConversion, fluToFrd) {
+  Eigen::Vector3f v_flu(1.F, 2.F, 3.F);
+  Eigen::Vector3f v_frd(1.F, -2.F, -3.F);
+  vectorsApproxEqualTest(v_frd, px4_ros2::fluToFrd(v_flu));
+}
+
+TEST(FrameConversion, varianceNedToEnu) {
+  Eigen::Vector3f v_enu(1.F, 2.F, 3.F);
+  Eigen::Vector3f v_ned(2.F, 1.F, 3.F);
+  vectorsApproxEqualTest(v_ned, px4_ros2::varianceNedToEnu(v_enu));
+}
+
+TEST(FrameConversion, varianceEnuToNed) {
+  Eigen::Vector3f v_enu(1.F, 2.F, 3.F);
+  Eigen::Vector3f v_ned(2.F, 1.F, 3.F);
+  vectorsApproxEqualTest(v_ned, px4_ros2::varianceEnuToNed(v_enu));
+}
+
+TEST(Geometry, yawBodyToWorld) {
+  float yaw;
+  Eigen::Vector3f point_body;
+  Eigen::Vector3f point_world;
+
+  yaw = 0.F;
+  point_body = Eigen::Vector3f(1.F, 2.F, 3.F);
+  vectorsApproxEqualTest(point_body, px4_ros2::yawBodyToWorld(yaw, point_body));
+
+  yaw = M_PI_2;
+  point_body = Eigen::Vector3f(1.F, 2.F, 3.F);
+  point_world = Eigen::Vector3f(-2.F, 1.F, 3.F);
+  vectorsApproxEqualTest(point_world, px4_ros2::yawBodyToWorld(yaw, point_body));
+
+  yaw = -3.F * M_PI / 4.F;
+  point_body = Eigen::Vector3f(1.F, 2.F, 3.F);
+  point_world = Eigen::Vector3f(std::sqrt(2) / 2, -3 / std::sqrt(2), 3.F);
+  vectorsApproxEqualTest(point_world, px4_ros2::yawBodyToWorld(yaw, point_body));
+
+  yaw = -M_PI_2 + 0.1F;
+  point_body = Eigen::Vector3f(1.F, 2.F, 3.F);
+  point_world = Eigen::Vector3f(
+    std::cos(yaw) * point_body.x() - std::sin(yaw) * point_body.y(),
+    std::sin(yaw) * point_body.x() + std::cos(yaw) * point_body.y(),
+    3.F
+  );
+  vectorsApproxEqualTest(point_world, px4_ros2::yawBodyToWorld(yaw, point_body));
+}

--- a/px4_ros2_cpp/test/unit/utils/geometry.cpp
+++ b/px4_ros2_cpp/test/unit/utils/geometry.cpp
@@ -1,0 +1,141 @@
+/****************************************************************************
+ * Copyright (c) 2024 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#include "util.hpp"
+
+#include <gtest/gtest.h>
+#include <px4_ros2/utils/geometry.hpp>
+
+
+TEST(Geometry, wrapPi) {
+  EXPECT_NEAR(M_PI_2, px4_ros2::wrapPi(M_PI_2), 1e-3);
+  EXPECT_NEAR(-M_PI_2, px4_ros2::wrapPi(-M_PI_2), 1e-3);
+  EXPECT_NEAR(0.F, px4_ros2::wrapPi(4 * M_PI), 1e-3);
+  EXPECT_NEAR(-3.F * M_PI / 4.F, px4_ros2::wrapPi(-11.F * M_PI / 4.F), 1e-3);
+  EXPECT_NEAR(3.F * M_PI / 4.F, px4_ros2::wrapPi(11.F * M_PI / 4.F), 1e-3);
+
+  // Absolute value due to floating point precision, 2*k*pi can map to -pi and pi
+  EXPECT_NEAR(M_PI, std::fabs(px4_ros2::wrapPi(-11.0 * M_PI)), 1e-3);
+}
+
+TEST(Geometry, quaternionToEulerRPY) {
+  Eigen::Quaternionf q;
+  Eigen::Vector3f v_euler;
+
+  // Roll
+  q = Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitX());
+  v_euler = Eigen::Vector3f{M_PI_2, 0.F, 0.F};
+  vectorsApproxEqualTest(v_euler, px4_ros2::quaternionToEulerRPY(q), "roll pi/2");
+
+  // Pitch
+  q = Eigen::AngleAxisf(-M_PI / 4.F, Eigen::Vector3f::UnitY());
+  v_euler = Eigen::Vector3f{0.F, -M_PI / 4.F, 0.F};
+  vectorsApproxEqualTest(v_euler, px4_ros2::quaternionToEulerRPY(q), "pitch -pi/4");
+
+  // Yaw
+  q = Eigen::AngleAxisf(3.F * M_PI / 4.F, Eigen::Vector3f::UnitZ());
+  v_euler = Eigen::Vector3f{0.F, 0.F, 3.F * M_PI / 4.F};
+  vectorsApproxEqualTest(v_euler, px4_ros2::quaternionToEulerRPY(q), "yaw 3pi/4");
+
+  // Gimbal lock cases
+  q = Eigen::AngleAxisf(-M_PI_2, Eigen::Vector3f::UnitY());
+  v_euler = Eigen::Vector3f{0.F, -M_PI_2, 0.F};
+  vectorsApproxEqualTest(v_euler, px4_ros2::quaternionToEulerRPY(q), "gimbal lock: pitch -pi/2");
+
+  q = Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitY());
+  v_euler = Eigen::Vector3f{0.F, M_PI_2, 0.F};
+  vectorsApproxEqualTest(v_euler, px4_ros2::quaternionToEulerRPY(q), "gimbal lock: pitch pi/2");
+
+  // Multi-axis rotations have multiple euler angle representations
+  // Therefore we convert euler angle back to quaternion and compare to that
+
+  q = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitZ());
+  quaternionToEulerReconstructionTest(q);
+
+  q = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI - 0.1F, Eigen::Vector3f::UnitZ());
+  quaternionToEulerReconstructionTest(q);
+
+  q = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI + 0.1F, Eigen::Vector3f::UnitZ());
+  quaternionToEulerReconstructionTest(q);
+
+  q = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitZ());
+  quaternionToEulerReconstructionTest(q);
+
+  q = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitZ());
+  quaternionToEulerReconstructionTest(q);
+
+  q = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-M_PI + 0.1F, Eigen::Vector3f::UnitZ());
+  quaternionToEulerReconstructionTest(q);
+
+  q = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-M_PI - 0.1F, Eigen::Vector3f::UnitZ());
+  quaternionToEulerReconstructionTest(q);
+
+  q = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitZ());
+  quaternionToEulerReconstructionTest(q);
+}
+
+TEST(Geometry, quaternionToRoll) {
+  Eigen::Quaternionf q;
+  float roll;
+
+  // 90 deg roll
+  q = Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitX());
+  roll = M_PI_2;
+  EXPECT_NEAR(roll, px4_ros2::quaternionToRoll(q), 1e-3);
+
+  // Rolled -45 deg along Y-axis
+  q = Eigen::AngleAxisf(-M_PI / 4.F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitZ());
+  roll = -M_PI / 4.F;
+  EXPECT_NEAR(roll, px4_ros2::quaternionToRoll(q), 1e-3);
+}
+
+TEST(Geometry, quaternionToPitch) {
+  Eigen::Quaternionf q;
+  float pitch;
+
+  // 90 deg pitch
+  q = Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitY());
+  pitch = M_PI_2;
+  EXPECT_NEAR(pitch, px4_ros2::quaternionToPitch(q), 1e-3);
+
+  // Rolled -45 deg along Y-axis
+  q = Eigen::AngleAxisf(-M_PI / 4.F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitZ());
+  pitch = 0.F;
+  EXPECT_NEAR(pitch, px4_ros2::quaternionToPitch(q), 1e-3);
+}
+
+TEST(Geometry, quaternionToYaw) {
+  Eigen::Quaternionf q;
+  float yaw;
+
+  // 90 deg yaw
+  q = Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitZ());
+  yaw = M_PI_2;
+  EXPECT_NEAR(yaw, px4_ros2::quaternionToYaw(q), 1e-3);
+
+  // Rolled -45 deg along Y-axis
+  q = Eigen::AngleAxisf(-M_PI / 4.F, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitZ());
+  yaw = M_PI_2;
+  EXPECT_NEAR(yaw, px4_ros2::quaternionToYaw(q), 1e-3);
+}

--- a/px4_ros2_cpp/test/unit/utils/util.cpp
+++ b/px4_ros2_cpp/test/unit/utils/util.cpp
@@ -1,0 +1,44 @@
+/****************************************************************************
+ * Copyright (c) 2024 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#include "util.hpp"
+#include <gtest/gtest.h>
+
+void quaternionsApproxEqualTest(
+  const Eigen::Quaternionf & q_expected,
+  const Eigen::Quaternionf & q_actual, const std::string & msg, const float precision)
+{
+  // quaternion with all inverted components is equivalent to itself
+  Eigen::Quaternionf q_expected_negated {-q_expected.w(), -q_expected.x(), -q_expected.y(),
+    -q_expected.z()};
+
+  EXPECT_TRUE(
+    q_expected.isApprox(
+      q_actual,
+      precision) || q_expected_negated.isApprox(q_actual, precision))
+    << "test: " << msg << std::endl
+    << "  q_actual: " << q_actual.coeffs().transpose() << std::endl
+    << "q_expected: " << q_expected.coeffs().transpose() << std::endl;
+}
+
+void vectorsApproxEqualTest(
+  const Eigen::Vector3f & v_expected, const Eigen::Vector3f & v_actual,
+  const std::string & msg, const float precision)
+{
+  EXPECT_TRUE(v_expected.isApprox(v_actual, precision))
+    << "test: " << msg << std::endl
+    << "  v_actual: " << v_actual.transpose() << std::endl
+    << "v_expected: " << v_expected.transpose() << std::endl;
+}
+
+void quaternionToEulerReconstructionTest(const Eigen::Quaternionf & q, const std::string & msg)
+{
+  Eigen::Vector3f v_euler = px4_ros2::quaternionToEulerRPY(q);
+  Eigen::Quaternionf reconstructed_quaternion =
+    Eigen::AngleAxisf(v_euler.z(), Eigen::Vector3f::UnitZ()) *
+    Eigen::AngleAxisf(v_euler.y(), Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(v_euler.x(), Eigen::Vector3f::UnitX());
+  quaternionsApproxEqualTest(q, reconstructed_quaternion, msg, 1e-3);
+}

--- a/px4_ros2_cpp/test/unit/utils/util.hpp
+++ b/px4_ros2_cpp/test/unit/utils/util.hpp
@@ -1,0 +1,23 @@
+/****************************************************************************
+ * Copyright (c) 2024 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <Eigen/Eigen>
+
+#include <px4_ros2/utils/geometry.hpp>
+
+void quaternionsApproxEqualTest(
+  const Eigen::Quaternionf & q_expected,
+  const Eigen::Quaternionf & q_actual, const std::string & msg = "", float precision = 1e-3);
+
+void vectorsApproxEqualTest(
+  const Eigen::Vector3f & v_expected, const Eigen::Vector3f & v_actual,
+  const std::string & msg = "", float precision = 1e-3);
+
+void quaternionToEulerReconstructionTest(
+  const Eigen::Quaternionf & q,
+  const std::string & msg = "");


### PR DESCRIPTION
### Moves utils from auterion_sdk
- Utils for commonly used geometry/math
- Utils for commonly used ROS2 PX4 conversions (ENU/NED, FRD/FLU)

### Changes
- templated methods
- `wrapAngleToPlusMinusPi` returns in [-pi, pi) instead of [-pi, pi] up to floating point precision
- rename `wrapAngleToPlusMinusPi` -> `wrapPi`
- Renamed `ned` to `frd` for thrust of attitude and rate setpoints
- Split auterion_sdk `utils.cpp` -> `{geometry.cpp, frame_conversion.cpp}`

### Adds
- `quaternionToPitch` (and `...Roll`, `...Yaw`) functions. Rationale: existing`quaternionToEuler` maps pitch to [-pi/2, pi/2] by convention but there are use cases for a pitch in [-pi, pi] i.e. accumulating delta angles to detect a flip.
- Utils unit tests
- Utils doxygen docs