### PR TITLE
refactor: switch to lower-case float literal suffix (f) 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -88,3 +88,5 @@ CheckOptions:
     value:           lower_case
   - key:             readability-identifier-naming.IgnoreMainLikeFunctions
     value:           1
+  - key:             readability-uppercase-literal-suffix.NewSuffixes
+    value:           'L;LL;LU;LLU;U;UL;ULL'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,6 +17,7 @@ Checks: >
   -misc-unused-parameters,
   -misc-no-recursion,
   -misc-confusable-identifiers,
+  -misc-include-cleaner,
   -modernize-return-braced-init-list,
   -modernize-use-trailing-return-type,
   -modernize-avoid-c-arrays,

--- a/examples/cpp/modes/goto/include/mode.hpp
+++ b/examples/cpp/modes/goto/include/mode.hpp
@@ -65,13 +65,13 @@ public:
       case State::GoingNorth: {
           // go north to the northwest corner facing in direction of travel
           const Eigen::Vector3f target_position_m = _start_position_m +
-            Eigen::Vector3f{kTriangleHeight, 0.F, 0.F};
+            Eigen::Vector3f{kTriangleHeight, 0.f, 0.f};
 
           const Eigen::Vector2f vehicle_to_target_xy = target_position_m.head(2) -
             _vehicle_local_position->positionNed().head(2);
           const float heading_target_rad = atan2f(vehicle_to_target_xy(1), vehicle_to_target_xy(0));
 
-          if (vehicle_to_target_xy.norm() < 0.1F) {
+          if (vehicle_to_target_xy.norm() < 0.1f) {
             // stop caring about heading (the arctangent becomes undefined)
             _goto_setpoint->update(target_position_m);
           } else {
@@ -87,19 +87,19 @@ public:
       case State::GoingEast: {
           // go to the northeast corner while spinning
           const Eigen::Vector3f target_position_m = _start_position_m +
-            Eigen::Vector3f{kTriangleHeight, kTriangleWidth, 0.F};
+            Eigen::Vector3f{kTriangleHeight, kTriangleWidth, 0.f};
 
           // scale the speed limits by distance to the target
           const Eigen::Vector2f vehicle_to_target_xy = target_position_m.head(2) -
             _vehicle_local_position->positionNed().head(2);
-          const float speed_scale = std::min(vehicle_to_target_xy.norm() / kTriangleWidth, 1.F);
+          const float speed_scale = std::min(vehicle_to_target_xy.norm() / kTriangleWidth, 1.f);
 
-          const float max_horizontal_velocity_m_s = 5.F * speed_scale + (1.F - speed_scale) * 1.F;
-          const float max_vertical_velocity_m_s = 3.F * speed_scale + (1.F - speed_scale) * 0.5F;
-          const float max_heading_rate_rad_s = (45.F * speed_scale + (1.F - speed_scale) * 25.F) *
-            static_cast<float>(M_PI) / 180.F;
+          const float max_horizontal_velocity_m_s = 5.f * speed_scale + (1.f - speed_scale) * 1.f;
+          const float max_vertical_velocity_m_s = 3.f * speed_scale + (1.f - speed_scale) * 0.5f;
+          const float max_heading_rate_rad_s = (45.f * speed_scale + (1.f - speed_scale) * 25.f) *
+            static_cast<float>(M_PI) / 180.f;
           const float heading_setpoint_rate_of_change =
-            (40.F * speed_scale + (1.F - speed_scale) * 20.F) * static_cast<float>(M_PI) / 180.F;
+            (40.f * speed_scale + (1.f - speed_scale) * 20.f) * static_cast<float>(M_PI) / 180.f;
 
           if (!_start_heading_set) {
             _spinning_heading_rad = _vehicle_heading_rad;
@@ -126,7 +126,7 @@ public:
       case State::GoingSouthwest: {
           // go to southwest corner while facing the northeastern corner
           const Eigen::Vector2f position_of_interest_m = _start_position_m.head(2) +
-            Eigen::Vector2f{kTriangleHeight, 0.F};
+            Eigen::Vector2f{kTriangleHeight, 0.f};
           const Eigen::Vector2f vehicle_to_poi_xy = position_of_interest_m -
             _vehicle_local_position->positionNed().head(2);
           const float heading_target_rad = atan2f(vehicle_to_poi_xy(1), vehicle_to_poi_xy(0));
@@ -142,8 +142,8 @@ public:
   }
 
 private:
-  static constexpr float kTriangleHeight = 20.F; // [m]
-  static constexpr float kTriangleWidth = 30.F; // [m]
+  static constexpr float kTriangleHeight = 20.f; // [m]
+  static constexpr float kTriangleWidth = 30.f; // [m]
 
   enum class State
   {
@@ -158,10 +158,10 @@ private:
   bool _start_position_set{false};
 
   // [-pi, pi] current vehicle heading from VehicleAttitude subscription
-  float _vehicle_heading_rad{0.F};
+  float _vehicle_heading_rad{0.f};
 
   // [-pi, pi] current heading setpoint during spinning phase
-  float _spinning_heading_rad{0.F};
+  float _spinning_heading_rad{0.f};
 
   // used for heading initialization when dynamically updating heading setpoints
   bool _start_heading_set{false};
@@ -179,8 +179,8 @@ private:
 
   bool positionReached(const Eigen::Vector3f & target_position_m) const
   {
-    static constexpr float kPositionErrorThreshold = 0.5F; // [m]
-    static constexpr float kVelocityErrorThreshold = 0.3F; // [m/s]
+    static constexpr float kPositionErrorThreshold = 0.5f; // [m]
+    static constexpr float kVelocityErrorThreshold = 0.3f; // [m/s]
     const Eigen::Vector3f position_error_m = target_position_m -
       _vehicle_local_position->positionNed();
     return (position_error_m.norm() < kPositionErrorThreshold) &&
@@ -189,7 +189,7 @@ private:
 
   bool headingReached(float target_heading_rad) const
   {
-    static constexpr float kHeadingErrorThreshold = 7.F * static_cast<float>(M_PI) / 180.F; // [rad]
+    static constexpr float kHeadingErrorThreshold = 7.f * static_cast<float>(M_PI) / 180.f; // [rad]
     const float heading_error_wrapped = wrapPi(target_heading_rad - _vehicle_heading_rad);
     return fabsf(heading_error_wrapped) < kHeadingErrorThreshold;
   }

--- a/examples/cpp/modes/goto/include/util.hpp
+++ b/examples/cpp/modes/goto/include/util.hpp
@@ -39,7 +39,7 @@ static inline float wrapPi(const float angle)
   }
 
   const float range = 2 * m_pi_f;
-  const float inv_range = 1.F / range;
+  const float inv_range = 1.f / range;
   const float num_wraps = std::floor((angle + m_pi_f) * inv_range);
   return angle - range * num_wraps;
 }

--- a/examples/cpp/modes/manual/include/mode.hpp
+++ b/examples/cpp/modes/manual/include/mode.hpp
@@ -56,27 +56,27 @@ public:
 
   void updateSetpoint(float dt_s) override
   {
-    const float threshold = 0.9F;
+    const float threshold = 0.9f;
     const bool want_rates = fabsf(_manual_control_input->roll()) > threshold || fabsf(
       _manual_control_input->pitch()) > threshold;
 
-    const float yaw_rate = _manual_control_input->yaw() * 120.F * M_PI_F / 180.F;
+    const float yaw_rate = _manual_control_input->yaw() * 120.f * M_PI_F / 180.f;
 
     if (want_rates) {
-      const Eigen::Vector3f thrust_sp{0.F, 0.F, -_manual_control_input->throttle()};
+      const Eigen::Vector3f thrust_sp{0.f, 0.f, -_manual_control_input->throttle()};
       const Eigen::Vector3f rates_sp{
-        _manual_control_input->roll() * 500.F * M_PI_F / 180.F,
-        -_manual_control_input->pitch() * 500.F * M_PI_F / 180.F,
+        _manual_control_input->roll() * 500.f * M_PI_F / 180.f,
+        -_manual_control_input->pitch() * 500.f * M_PI_F / 180.f,
         yaw_rate
       };
       _rates_setpoint->update(rates_sp, thrust_sp);
 
     } else {
       _yaw += yaw_rate * dt_s;
-      const Eigen::Vector3f thrust_sp{0.F, 0.F, -_manual_control_input->throttle()};
+      const Eigen::Vector3f thrust_sp{0.f, 0.f, -_manual_control_input->throttle()};
       const Eigen::Quaternionf qd = quaternionFromEuler(
-        _manual_control_input->roll() * 55.F * M_PI_F / 180.F,
-        -_manual_control_input->pitch() * 55.F * M_PI_F / 180.F,
+        _manual_control_input->roll() * 55.f * M_PI_F / 180.f,
+        -_manual_control_input->pitch() * 55.f * M_PI_F / 180.f,
         _yaw
       );
       _attitude_setpoint->update(qd, thrust_sp, yaw_rate);
@@ -91,7 +91,7 @@ private:
   std::shared_ptr<px4_ros2::RatesSetpointType> _rates_setpoint;
   std::shared_ptr<px4_ros2::AttitudeSetpointType> _attitude_setpoint;
   std::shared_ptr<px4_ros2::PeripheralActuatorControls> _peripheral_actuator_controls;
-  float _yaw{0.F};
+  float _yaw{0.f};
 };
 
 class TestNode : public rclcpp::Node

--- a/examples/cpp/modes/mode_with_executor/include/mode.hpp
+++ b/examples/cpp/modes/mode_with_executor/include/mode.hpp
@@ -46,7 +46,7 @@ public:
     }
 
     const float elapsed_s = (now - _activation_time).seconds();
-    const Eigen::Vector3f velocity{10.F, elapsed_s * 2.F, -2.F};
+    const Eigen::Vector3f velocity{10.f, elapsed_s * 2.f, -2.f};
     _trajectory_setpoint->update(velocity);
   }
 

--- a/examples/cpp/modes/rtl_replacement/include/mode.hpp
+++ b/examples/cpp/modes/rtl_replacement/include/mode.hpp
@@ -49,7 +49,7 @@ public:
       return;
     }
 
-    const Eigen::Vector3f velocity{0.F, 1.F, 5.F};
+    const Eigen::Vector3f velocity{0.f, 1.f, 5.f};
     _trajectory_setpoint->update(velocity);
   }
 

--- a/examples/cpp/navigation/global_navigation/include/global_navigation.hpp
+++ b/examples/cpp/navigation/global_navigation/include/global_navigation.hpp
@@ -29,10 +29,10 @@ public:
     global_position_measurement.timestamp_sample = _node.get_clock()->now();
 
     global_position_measurement.lat_lon = Eigen::Vector2d {12.34321, 23.45432};
-    global_position_measurement.horizontal_variance = 0.1F;
+    global_position_measurement.horizontal_variance = 0.1f;
 
-    global_position_measurement.altitude_msl = 12.4F;
-    global_position_measurement.vertical_variance = 0.2F;
+    global_position_measurement.altitude_msl = 12.4f;
+    global_position_measurement.vertical_variance = 0.2f;
 
     try {
       update(global_position_measurement);

--- a/examples/cpp/navigation/local_navigation/include/local_navigation.hpp
+++ b/examples/cpp/navigation/local_navigation/include/local_navigation.hpp
@@ -29,10 +29,10 @@ public:
 
     local_position_measurement.timestamp_sample = _node.get_clock()->now();
 
-    local_position_measurement.velocity_xy = Eigen::Vector2f {1.F, 2.F};
-    local_position_measurement.velocity_xy_variance = Eigen::Vector2f {0.3F, 0.4F};
+    local_position_measurement.velocity_xy = Eigen::Vector2f {1.f, 2.f};
+    local_position_measurement.velocity_xy_variance = Eigen::Vector2f {0.3f, 0.4f};
 
-    local_position_measurement.position_z = 12.3F;
+    local_position_measurement.position_z = 12.3f;
     local_position_measurement.position_z_variance = 0.33F;
 
     local_position_measurement.attitude_quaternion = Eigen::Quaternionf {0.1, -0.2, 0.3, 0.25};

--- a/px4_ros2_cpp/include/px4_ros2/common/setpoint_base.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/common/setpoint_base.hpp
@@ -65,7 +65,7 @@ public:
 
   virtual Configuration getConfiguration() = 0;
 
-  virtual float desiredUpdateRateHz() {return 50.F;}
+  virtual float desiredUpdateRateHz() {return 50.f;}
 
 
   void setShouldActivateCallback(const ShouldActivateCB & should_activate_cb)

--- a/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
@@ -199,7 +199,7 @@ private:
   bool _is_armed{false};       ///< Is vehicle armed?
   bool _completed{false};       ///< Is mode completed?
 
-  float _setpoint_update_rate_hz{0.F};
+  float _setpoint_update_rate_hz{0.f};
   rclcpp::TimerBase::SharedPtr _setpoint_update_timer;
   rclcpp::Time _last_setpoint_update{};
 

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/direct_actuators.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/direct_actuators.hpp
@@ -31,7 +31,7 @@ public:
   ~DirectActuatorsSetpointType() override = default;
 
   Configuration getConfiguration() override;
-  float desiredUpdateRateHz() override {return 500.F;}
+  float desiredUpdateRateHz() override {return 500.f;}
 
   /**
    * Send servos setpoint

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/attitude.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/attitude.hpp
@@ -24,11 +24,11 @@ public:
   ~AttitudeSetpointType() override = default;
 
   Configuration getConfiguration() override;
-  float desiredUpdateRateHz() override {return 200.F;}
+  float desiredUpdateRateHz() override {return 200.f;}
 
   void update(
     const Eigen::Quaternionf & attidude_setpoint,
-    const Eigen::Vector3f & thrust_setpoint_frd, float yaw_sp_move_rate_rad_s = 0.F);
+    const Eigen::Vector3f & thrust_setpoint_frd, float yaw_sp_move_rate_rad_s = 0.f);
 
 private:
   rclcpp::Node & _node;

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/rates.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/rates.hpp
@@ -24,7 +24,7 @@ public:
   ~RatesSetpointType() override = default;
 
   Configuration getConfiguration() override;
-  float desiredUpdateRateHz() override {return 500.F;}
+  float desiredUpdateRateHz() override {return 500.f;}
 
   void update(
     const Eigen::Vector3f & rate_setpoints_ned_rad,

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/goto.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/goto.hpp
@@ -45,7 +45,7 @@ public:
     const std::optional<float> & max_heading_rate = {}
   );
 
-  float desiredUpdateRateHz() override {return 30.F;}
+  float desiredUpdateRateHz() override {return 30.f;}
 
 private:
   rclcpp::Node & _node;

--- a/px4_ros2_cpp/src/components/message_compatibility_check.cpp
+++ b/px4_ros2_cpp/src/components/message_compatibility_check.cpp
@@ -15,10 +15,9 @@
 #include <regex>
 #include <unistd.h>
 
-namespace px4_ros2
+namespace
 {
-
-static std::string messageFieldsStrForMessageHash(
+std::string messageFieldsStrForMessageHash(
   rclcpp::Node & node,
   const std::string & topic_type,
   const std::string & msgs_dir)
@@ -38,9 +37,21 @@ static std::string messageFieldsStrForMessageHash(
     R"((?:^|\n)\s*([a-zA-Z0-9_/]+)(\[[^\]]*\])?\s+(\w+)[ \t]*(=)?)"};
 
   static const std::set<std::string> kBasicTypes{
-    {"bool"}, {"byte"}, {"char"}, {"float32"}, {"float64"}, {"int8"},
-    {"uint8"}, {"int16"}, {"uint16"}, {"int32"}, {"uint32"}, {"int64"},
-    {"uint64"}, {"string"}, {"wstring"}};
+    {"bool"},
+    {"byte"},
+    {"char"},
+    {"float32"},
+    {"float64"},
+    {"int8"},
+    {"uint8"},
+    {"int16"},
+    {"uint16"},
+    {"int32"},
+    {"uint32"},
+    {"int64"},
+    {"uint64"},
+    {"string"},
+    {"wstring"}};
 
   for (std::sregex_iterator iter(text.begin(), text.end(), kMsgFieldTypeRegex);
     iter != std::sregex_iterator(); ++iter)
@@ -74,6 +85,7 @@ static std::string messageFieldsStrForMessageHash(
 // source: https://gist.github.com/ruby0x1/81308642d0325fd386237cfa3b44785c
 constexpr uint32_t kVal32Const = 0x811c9dc5;
 constexpr uint32_t kPrime32Const = 0x1000193;
+
 inline constexpr uint32_t hash32Fnv1aConst(
   const char * const str,
   const uint32_t value = kVal32Const) noexcept
@@ -83,7 +95,7 @@ inline constexpr uint32_t hash32Fnv1aConst(
       str[0])) * kPrime32Const);
 }
 
-static uint32_t messageHash(
+uint32_t messageHash(
   rclcpp::Node & node, const std::string & topic_type,
   const std::string & msgs_dir)
 {
@@ -91,11 +103,11 @@ static uint32_t messageHash(
   return hash32Fnv1aConst(message_fields_str.c_str());
 }
 
-static std::string snakeToCamelCase(std::string s) noexcept
+std::string snakeToCamelCase(std::string s) noexcept
 {
   bool tail = false;
   std::size_t n = 0;
-  for (const unsigned char c : s) {
+  for (const unsigned char c: s) {
     if (c == '-' || c == '_') {
       tail = false;
     } else if (tail) {
@@ -116,7 +128,7 @@ enum class RequestMessageFormatReturn
   ProtocolVersionMismatch,
 };
 
-static RequestMessageFormatReturn requestMessageFormat(
+RequestMessageFormatReturn requestMessageFormat(
   rclcpp::Node & node, const px4_msgs::msg::MessageFormatRequest & request,
   const rclcpp::Subscription<px4_msgs::msg::MessageFormatResponse>::SharedPtr & message_format_response_sub,
   const rclcpp::Publisher<px4_msgs::msg::MessageFormatRequest>::SharedPtr & message_format_request_pub,
@@ -202,6 +214,11 @@ static RequestMessageFormatReturn requestMessageFormat(
   wait_set.remove_subscription(message_format_response_sub);
   return request_message_format_return;
 }
+
+} // namespace
+
+namespace px4_ros2
+{
 
 bool messageCompatibilityCheck(
   rclcpp::Node & node, const std::vector<MessageCompatibilityTopic> & messages_to_check,

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -100,7 +100,7 @@ void ModeBase::callOnActivate()
   onActivate();
 
   if (_setpoint_update_rate_hz > FLT_EPSILON) {
-    updateSetpoint(1.F / _setpoint_update_rate_hz);             // Immediately update
+    updateSetpoint(1.f / _setpoint_update_rate_hz);             // Immediately update
   }
 
   updateSetpointUpdateTimer();
@@ -122,7 +122,7 @@ void ModeBase::updateSetpointUpdateTimer()
     if (!_setpoint_update_timer) {
       _setpoint_update_timer = node().create_wall_timer(
         std::chrono::milliseconds(
-          static_cast<int64_t>(1000.F /
+          static_cast<int64_t>(1000.f /
           _setpoint_update_rate_hz)), [this]() {
           const auto now = node().get_clock()->now();
           const float dt_s = (now - _last_setpoint_update).seconds();
@@ -260,13 +260,13 @@ void ModeBase::updateModeRequirementsFromSetpoints()
 void ModeBase::setSetpointUpdateRateFromSetpointTypes()
 {
   // Set update rate based on setpoint types
-  float max_update_rate = -1.F;
+  float max_update_rate = -1.f;
   for (const auto & setpoint_type : _setpoint_types) {
     if (setpoint_type->desiredUpdateRateHz() > max_update_rate) {
       max_update_rate = setpoint_type->desiredUpdateRateHz();
     }
   }
-  if (max_update_rate > 0.F) {
+  if (max_update_rate > 0.f) {
     setSetpointUpdateRate(max_update_rate);
   }
 }

--- a/px4_ros2_cpp/src/components/mode_executor.cpp
+++ b/px4_ros2_cpp/src/components/mode_executor.cpp
@@ -245,7 +245,7 @@ void ModeExecutorBase::arm(const CompletedCallback & on_completed)
 
   const Result result = sendCommandSync(
     px4_msgs::msg::VehicleCommand::VEHICLE_CMD_COMPONENT_ARM_DISARM,
-    1.F);
+    1.f);
 
   if (result != Result::Success) {
     on_completed(result);

--- a/px4_ros2_cpp/src/control/setpoint_types/goto.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/goto.cpp
@@ -32,15 +32,15 @@ void GotoSetpointType::update(
   sp.position[0] = position(0);
   sp.position[1] = position(1);
   sp.position[2] = position(2);
-  sp.heading = heading.value_or(0.F);
+  sp.heading = heading.value_or(0.f);
 
   // setpoint flags
   sp.flag_control_heading = heading.has_value();
 
   // constraints
-  sp.max_horizontal_speed = max_horizontal_speed.value_or(0.F);
-  sp.max_vertical_speed = max_vertical_speed.value_or(0.F);
-  sp.max_heading_rate = max_heading_rate.value_or(0.F);
+  sp.max_horizontal_speed = max_horizontal_speed.value_or(0.f);
+  sp.max_vertical_speed = max_vertical_speed.value_or(0.f);
+  sp.max_heading_rate = max_heading_rate.value_or(0.f);
 
   // constraint flags
   sp.flag_set_max_horizontal_speed = max_horizontal_speed.has_value();

--- a/px4_ros2_cpp/test/integration/global_navigation.cpp
+++ b/px4_ros2_cpp/test/integration/global_navigation.cpp
@@ -109,7 +109,7 @@ TEST_F(GlobalPositionInterfaceTest, fuseAll) {
   auto measurement = std::make_unique<GlobalPositionMeasurement>();
   measurement->lat_lon = Eigen::Vector2d {12.34567, 23.45678};
   measurement->horizontal_variance = 0.01F;
-  measurement->altitude_msl = 123.F;
+  measurement->altitude_msl = 123.f;
   measurement->vertical_variance = 0.01F;
   waitForMeasurementUpdate(
     std::move(measurement), [](const EstimatorStatusFlags::UniquePtr & flags) {

--- a/px4_ros2_cpp/test/integration/local_navigation.cpp
+++ b/px4_ros2_cpp/test/integration/local_navigation.cpp
@@ -114,9 +114,9 @@ protected:
 
 TEST_F(LocalPositionInterfaceTest, fuseEvPos) {
   auto measurement = std::make_unique<LocalPositionMeasurement>();
-  measurement->position_xy = Eigen::Vector2f {0.F, 0.F};
-  measurement->position_xy_variance = Eigen::Vector2f {0.1F, 0.1F};
-  measurement->position_z = 0.F;
+  measurement->position_xy = Eigen::Vector2f {0.f, 0.f};
+  measurement->position_xy_variance = Eigen::Vector2f {0.1f, 0.1f};
+  measurement->position_z = 0.f;
   measurement->position_z_variance = 0.01F;
 
   waitForMeasurementUpdate(
@@ -127,10 +127,10 @@ TEST_F(LocalPositionInterfaceTest, fuseEvPos) {
 
 TEST_F(LocalPositionInterfaceTest, fuseEvVel) {
   auto measurement = std::make_unique<LocalPositionMeasurement>();
-  measurement->velocity_xy = Eigen::Vector2f {0.F, 0.F};
-  measurement->velocity_xy_variance = Eigen::Vector2f {0.1F, 0.1F};
-  measurement->velocity_z = 0.0F;
-  measurement->velocity_z_variance = 0.1F;
+  measurement->velocity_xy = Eigen::Vector2f {0.f, 0.f};
+  measurement->velocity_xy_variance = Eigen::Vector2f {0.1f, 0.1f};
+  measurement->velocity_z = 0.0f;
+  measurement->velocity_z_variance = 0.1f;
 
   waitForMeasurementUpdate(
     std::move(measurement), [](const EstimatorStatusFlags::UniquePtr & flags) {
@@ -142,7 +142,7 @@ TEST_F(LocalPositionInterfaceTest, fuseEvYaw) {
   auto measurement = std::make_unique<LocalPositionMeasurement>();
   measurement->attitude_quaternion =
     Eigen::Quaternionf(Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitZ()));  // East
-  measurement->attitude_variance = Eigen::Vector3f {0.1F, 0.1F, 0.1F};
+  measurement->attitude_variance = Eigen::Vector3f {0.1f, 0.1f, 0.1f};
 
   waitForMeasurementUpdate(
     std::move(measurement), [](const EstimatorStatusFlags::UniquePtr & flags) {
@@ -152,17 +152,17 @@ TEST_F(LocalPositionInterfaceTest, fuseEvYaw) {
 
 TEST_F(LocalPositionInterfaceTest, fuseAll) {
   auto measurement = std::make_unique<LocalPositionMeasurement>();
-  measurement->position_xy = Eigen::Vector2f {0.F, 0.F};
-  measurement->position_xy_variance = Eigen::Vector2f {0.1F, 0.1F};
-  measurement->position_z = 0.F;
-  measurement->position_z_variance = 0.1F;
-  measurement->velocity_xy = Eigen::Vector2f {0.F, 0.F};
-  measurement->velocity_xy_variance = Eigen::Vector2f {0.1F, 0.1F};
-  measurement->velocity_z = 0.0F;
-  measurement->velocity_z_variance = 0.1F;
+  measurement->position_xy = Eigen::Vector2f {0.f, 0.f};
+  measurement->position_xy_variance = Eigen::Vector2f {0.1f, 0.1f};
+  measurement->position_z = 0.f;
+  measurement->position_z_variance = 0.1f;
+  measurement->velocity_xy = Eigen::Vector2f {0.f, 0.f};
+  measurement->velocity_xy_variance = Eigen::Vector2f {0.1f, 0.1f};
+  measurement->velocity_z = 0.0f;
+  measurement->velocity_z_variance = 0.1f;
   measurement->attitude_quaternion =
     Eigen::Quaternionf(Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitZ()));  // East
-  measurement->attitude_variance = Eigen::Vector3f {0.1F, 0.1F, 0.1F};
+  measurement->attitude_variance = Eigen::Vector3f {0.1f, 0.1f, 0.1f};
 
   waitForMeasurementUpdate(
     std::move(measurement), [](const EstimatorStatusFlags::UniquePtr & flags) {

--- a/px4_ros2_cpp/test/integration/mode.cpp
+++ b/px4_ros2_cpp/test/integration/mode.cpp
@@ -59,8 +59,8 @@ public:
     ++num_setpoint_updates;
 
     // Send some random setpoints, make sure it stays in the air, we don't want it to land
-    const Eigen::Vector3f thrust{0.F, 0.F, -0.6F};
-    const Eigen::Quaternionf attitude{1.F, 0.F, 0.F, 0.F};
+    const Eigen::Vector3f thrust{0.f, 0.f, -0.6f};
+    const Eigen::Quaternionf attitude{1.f, 0.f, 0.f, 0.f};
     _attitude_setpoint->update(attitude, thrust);
   }
 
@@ -184,7 +184,7 @@ void TestExecution::run()
           _mode->check_should_fail = true;
           _vehicle_state.sendCommand(
             px4_msgs::msg::VehicleCommand::VEHICLE_CMD_COMPONENT_ARM_DISARM,
-            1.F);
+            1.f);
           _testing_timer = _node.create_wall_timer(
             5s, [this] {
               EXPECT_TRUE(_was_armed);

--- a/px4_ros2_cpp/test/integration/mode_executor.cpp
+++ b/px4_ros2_cpp/test/integration/mode_executor.cpp
@@ -62,7 +62,7 @@ public:
 
     // Send some random setpoints
     const float elapsed_s = (now - _activation_time).seconds();
-    const Eigen::Vector3f velocity{5.F, elapsed_s, 0.F};
+    const Eigen::Vector3f velocity{5.f, elapsed_s, 0.f};
     _trajectory_setpoint->update(velocity);
   }
 

--- a/px4_ros2_cpp/test/integration/overrides.cpp
+++ b/px4_ros2_cpp/test/integration/overrides.cpp
@@ -61,7 +61,7 @@ public:
 
     // Send some random setpoints
     const float elapsed_s = (now - _activation_time).seconds();
-    const Eigen::Vector3f velocity{5.F, elapsed_s, 0.F};
+    const Eigen::Vector3f velocity{5.f, elapsed_s, 0.f};
     _trajectory_setpoint->update(velocity);
   }
 

--- a/px4_ros2_cpp/test/unit/global_navigation.cpp
+++ b/px4_ros2_cpp/test/unit/global_navigation.cpp
@@ -62,7 +62,7 @@ TEST_F(GlobalPositionInterfaceTest, TimestampMissing) {
   GlobalPositionMeasurement measurement{};
 
   measurement.lat_lon = Eigen::Vector2d {12.34567, 23.45678};
-  measurement.horizontal_variance = 0.1F;
+  measurement.horizontal_variance = 0.1f;
   EXPECT_THROW(
     _global_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -84,7 +84,7 @@ TEST_F(GlobalPositionInterfaceTest, VarianceInvalid) {
   // Send altitude without variance
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.altitude_msl = 123.F;
+  measurement.altitude_msl = 123.f;
   EXPECT_THROW(
     _global_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -98,7 +98,7 @@ TEST_F(GlobalPositionInterfaceTest, ContainsNAN) {
   // Send lat lon with NAN
   measurement.timestamp_sample = _node->get_clock()->now();
   measurement.lat_lon = Eigen::Vector2d {NAN, 23.45678};
-  measurement.horizontal_variance = 0.1F;
+  measurement.horizontal_variance = 0.1f;
   EXPECT_THROW(
     _global_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -117,7 +117,7 @@ TEST_F(GlobalPositionInterfaceTest, ContainsNAN) {
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
   measurement.altitude_msl = NAN;
-  measurement.vertical_variance = 0.1F;
+  measurement.vertical_variance = 0.1f;
   EXPECT_THROW(
     _global_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -125,7 +125,7 @@ TEST_F(GlobalPositionInterfaceTest, ContainsNAN) {
 
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.altitude_msl = 123.F;
+  measurement.altitude_msl = 123.f;
   measurement.vertical_variance = NAN;
   EXPECT_THROW(
     _global_navigation_interface->update(measurement),

--- a/px4_ros2_cpp/test/unit/local_navigation.cpp
+++ b/px4_ros2_cpp/test/unit/local_navigation.cpp
@@ -113,8 +113,8 @@ TEST_F(LocalPositionInterfaceTest, MeasurementEmpty) {
 TEST_F(LocalPositionInterfaceTest, TimestampMissing) {
   LocalPositionMeasurement measurement{};
 
-  measurement.position_xy = Eigen::Vector2f {1.F, 2.F};
-  measurement.position_xy_variance = Eigen::Vector2f {0.2F, 0.1F};
+  measurement.position_xy = Eigen::Vector2f {1.f, 2.f};
+  measurement.position_xy_variance = Eigen::Vector2f {0.2f, 0.1f};
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -127,7 +127,7 @@ TEST_F(LocalPositionInterfaceTest, VarianceInvalid) {
 
   // Send position_xy without variance
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.position_xy = Eigen::Vector2f {1.F, 2.F};
+  measurement.position_xy = Eigen::Vector2f {1.f, 2.f};
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -136,7 +136,7 @@ TEST_F(LocalPositionInterfaceTest, VarianceInvalid) {
   // Send position_z without variance
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.position_z = 12.3F;
+  measurement.position_z = 12.3f;
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -145,7 +145,7 @@ TEST_F(LocalPositionInterfaceTest, VarianceInvalid) {
   // Send velocity_xy without variance
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.velocity_xy = Eigen::Vector2f {1.F, 2.F};
+  measurement.velocity_xy = Eigen::Vector2f {1.f, 2.f};
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -154,7 +154,7 @@ TEST_F(LocalPositionInterfaceTest, VarianceInvalid) {
   // Send velocity_z without variance
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.velocity_z = 12.3F;
+  measurement.velocity_z = 12.3f;
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -163,7 +163,7 @@ TEST_F(LocalPositionInterfaceTest, VarianceInvalid) {
   // Send attitude without variance
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.attitude_quaternion = Eigen::Quaternionf {0.1F, -0.2F, 0.3F, 0.25F};
+  measurement.attitude_quaternion = Eigen::Quaternionf {0.1f, -0.2f, 0.3f, 0.25F};
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -176,8 +176,8 @@ TEST_F(LocalPositionInterfaceTest, ContainsNAN) {
 
   // Send position_xy with NAN
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.position_xy = Eigen::Vector2f {NAN, 2.F};
-  measurement.position_xy_variance = Eigen::Vector2f {0.2F, 0.1F};
+  measurement.position_xy = Eigen::Vector2f {NAN, 2.f};
+  measurement.position_xy_variance = Eigen::Vector2f {0.2f, 0.1f};
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -185,8 +185,8 @@ TEST_F(LocalPositionInterfaceTest, ContainsNAN) {
 
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.position_xy = Eigen::Vector2f {1.F, 2.F};
-  measurement.position_xy_variance = Eigen::Vector2f {NAN, 0.1F};
+  measurement.position_xy = Eigen::Vector2f {1.f, 2.f};
+  measurement.position_xy_variance = Eigen::Vector2f {NAN, 0.1f};
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -204,7 +204,7 @@ TEST_F(LocalPositionInterfaceTest, ContainsNAN) {
 
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.position_z = 12.3F;
+  measurement.position_z = 12.3f;
   measurement.position_z_variance = NAN;
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
@@ -214,8 +214,8 @@ TEST_F(LocalPositionInterfaceTest, ContainsNAN) {
   // Send velocity_xy with NAN
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.velocity_xy = Eigen::Vector2f {NAN, 2.F};
-  measurement.velocity_xy_variance = Eigen::Vector2f {0.3F, 0.4F};
+  measurement.velocity_xy = Eigen::Vector2f {NAN, 2.f};
+  measurement.velocity_xy_variance = Eigen::Vector2f {0.3f, 0.4f};
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -223,8 +223,8 @@ TEST_F(LocalPositionInterfaceTest, ContainsNAN) {
 
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.velocity_xy = Eigen::Vector2f {1.F, 2.F};
-  measurement.velocity_xy_variance = Eigen::Vector2f {NAN, 0.4F};
+  measurement.velocity_xy = Eigen::Vector2f {1.f, 2.f};
+  measurement.velocity_xy_variance = Eigen::Vector2f {NAN, 0.4f};
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -242,7 +242,7 @@ TEST_F(LocalPositionInterfaceTest, ContainsNAN) {
 
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.velocity_z = 12.3F;
+  measurement.velocity_z = 12.3f;
   measurement.velocity_z_variance = NAN;
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
@@ -252,8 +252,8 @@ TEST_F(LocalPositionInterfaceTest, ContainsNAN) {
   // Send attitude with NAN
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.attitude_quaternion = Eigen::Quaternionf {NAN, -0.2F, 0.3F, 0.25F};
-  measurement.attitude_variance = Eigen::Vector3f {0.2F, 0.1F, 0.05F};
+  measurement.attitude_quaternion = Eigen::Quaternionf {NAN, -0.2f, 0.3f, 0.25F};
+  measurement.attitude_variance = Eigen::Vector3f {0.2f, 0.1f, 0.05F};
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -261,8 +261,8 @@ TEST_F(LocalPositionInterfaceTest, ContainsNAN) {
 
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.attitude_quaternion = Eigen::Quaternionf {0.1F, -0.2F, 0.3F, 0.25F};
-  measurement.attitude_variance = Eigen::Vector3f {NAN, 0.1F, 0.05F};
+  measurement.attitude_quaternion = Eigen::Quaternionf {0.1f, -0.2f, 0.3f, 0.25F};
+  measurement.attitude_variance = Eigen::Vector3f {NAN, 0.1f, 0.05F};
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -276,8 +276,8 @@ TEST_F(LocalPositionInterfacePoseTest, PoseFrameUnknown) {
   // Send position_xy and variance
   // Expects success
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.position_xy = Eigen::Vector2f {1.F, 2.F};
-  measurement.position_xy_variance = Eigen::Vector2f {0.2F, 0.1F};
+  measurement.position_xy = Eigen::Vector2f {1.f, 2.f};
+  measurement.position_xy_variance = Eigen::Vector2f {0.2f, 0.1f};
   EXPECT_NO_THROW(_local_navigation_interface->update(measurement)) <<
     "Failed to send position update (position_xy) with known pose frame and unknown velocity frame.";
 
@@ -285,7 +285,7 @@ TEST_F(LocalPositionInterfacePoseTest, PoseFrameUnknown) {
   // Expects success
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.position_z = 12.3F;
+  measurement.position_z = 12.3f;
   measurement.position_z_variance = 0.33F;
   EXPECT_NO_THROW(_local_navigation_interface->update(measurement)) <<
     "Failed to send position update (position_z) with known pose frame and unknown velocity frame.";
@@ -294,8 +294,8 @@ TEST_F(LocalPositionInterfacePoseTest, PoseFrameUnknown) {
   // Expects exception
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.velocity_xy = Eigen::Vector2f {1.F, 2.F};
-  measurement.velocity_xy_variance = Eigen::Vector2f {0.3F, 0.4F};
+  measurement.velocity_xy = Eigen::Vector2f {1.f, 2.f};
+  measurement.velocity_xy_variance = Eigen::Vector2f {0.3f, 0.4f};
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -305,7 +305,7 @@ TEST_F(LocalPositionInterfacePoseTest, PoseFrameUnknown) {
   // Expects exception
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.velocity_z = 12.3F;
+  measurement.velocity_z = 12.3f;
   measurement.velocity_z_variance = 0.33F;
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
@@ -320,8 +320,8 @@ TEST_F(LocalPositionInterfaceVelocityTest, VelocityFrameUnknown) {
   // Send position_xy and variance
   // Expects exception
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.position_xy = Eigen::Vector2f {1.F, 2.F};
-  measurement.position_xy_variance = Eigen::Vector2f {0.2F, 0.1F};
+  measurement.position_xy = Eigen::Vector2f {1.f, 2.f};
+  measurement.position_xy_variance = Eigen::Vector2f {0.2f, 0.1f};
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
     NavigationInterfaceInvalidArgument) <<
@@ -331,7 +331,7 @@ TEST_F(LocalPositionInterfaceVelocityTest, VelocityFrameUnknown) {
   // Expects exception
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.position_z = 12.3F;
+  measurement.position_z = 12.3f;
   measurement.position_z_variance = 0.33F;
   EXPECT_THROW(
     _local_navigation_interface->update(measurement),
@@ -342,8 +342,8 @@ TEST_F(LocalPositionInterfaceVelocityTest, VelocityFrameUnknown) {
   // Expects success
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.velocity_xy = Eigen::Vector2f {1.F, 2.F};
-  measurement.velocity_xy_variance = Eigen::Vector2f {0.3F, 0.4F};
+  measurement.velocity_xy = Eigen::Vector2f {1.f, 2.f};
+  measurement.velocity_xy_variance = Eigen::Vector2f {0.3f, 0.4f};
   EXPECT_NO_THROW(_local_navigation_interface->update(measurement)) <<
     "Failed to send velocity update (velocity_xy) with known velocity frame and unknown pose frame.";
 
@@ -351,7 +351,7 @@ TEST_F(LocalPositionInterfaceVelocityTest, VelocityFrameUnknown) {
   // Expects success
   measurement = {};
   measurement.timestamp_sample = _node->get_clock()->now();
-  measurement.velocity_z = 12.3F;
+  measurement.velocity_z = 12.3f;
   measurement.velocity_z_variance = 0.33F;
   EXPECT_NO_THROW(_local_navigation_interface->update(measurement)) <<
     "Failed to send velocity update (velocity_z) with known velocity frame and unknown pose frame.";

--- a/px4_ros2_cpp/test/unit/utils/frame_conversion.cpp
+++ b/px4_ros2_cpp/test/unit/utils/frame_conversion.cpp
@@ -10,27 +10,27 @@
 
 
 TEST(FrameConversion, yawNedToEnu) {
-  EXPECT_FLOAT_EQ(M_PI_2, px4_ros2::yawNedToEnu(0.F));
-  EXPECT_FLOAT_EQ(M_PI / 4.F, px4_ros2::yawNedToEnu(M_PI / 4.F));
+  EXPECT_FLOAT_EQ(M_PI_2, px4_ros2::yawNedToEnu(0.f));
+  EXPECT_FLOAT_EQ(M_PI / 4.f, px4_ros2::yawNedToEnu(M_PI / 4.f));
   EXPECT_FLOAT_EQ(-M_PI_2, px4_ros2::yawNedToEnu(M_PI));
   EXPECT_FLOAT_EQ(M_PI, std::fabs(px4_ros2::yawNedToEnu(-M_PI_2)));
 }
 
 TEST(FrameConversion, yawEnuToNed) {
-  EXPECT_FLOAT_EQ(M_PI_2, px4_ros2::yawEnuToNed(0.F));
-  EXPECT_FLOAT_EQ(M_PI / 4.F, px4_ros2::yawEnuToNed(M_PI / 4.F));
+  EXPECT_FLOAT_EQ(M_PI_2, px4_ros2::yawEnuToNed(0.f));
+  EXPECT_FLOAT_EQ(M_PI / 4.f, px4_ros2::yawEnuToNed(M_PI / 4.f));
   EXPECT_FLOAT_EQ(-M_PI_2, px4_ros2::yawEnuToNed(M_PI));
   EXPECT_FLOAT_EQ(M_PI, std::fabs(px4_ros2::yawEnuToNed(-M_PI_2)));
 }
 
 TEST(FrameConversion, yawRateNedToEnu) {
-  EXPECT_FLOAT_EQ(0.F, px4_ros2::yawRateNedToEnu(0.F));
-  EXPECT_FLOAT_EQ(12.3F, px4_ros2::yawRateNedToEnu(-12.3F));
+  EXPECT_FLOAT_EQ(0.f, px4_ros2::yawRateNedToEnu(0.f));
+  EXPECT_FLOAT_EQ(12.3f, px4_ros2::yawRateNedToEnu(-12.3f));
 }
 
 TEST(FrameConversion, yawRateEnuToNed) {
-  EXPECT_FLOAT_EQ(0.F, px4_ros2::yawRateEnuToNed(0.F));
-  EXPECT_FLOAT_EQ(12.3F, px4_ros2::yawRateEnuToNed(-12.3F));
+  EXPECT_FLOAT_EQ(0.f, px4_ros2::yawRateEnuToNed(0.f));
+  EXPECT_FLOAT_EQ(12.3f, px4_ros2::yawRateEnuToNed(-12.3f));
 }
 
 TEST(FrameConversion, attitudeNedToEnu) {
@@ -43,68 +43,68 @@ TEST(FrameConversion, attitudeNedToEnu) {
   quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
 
   // Test various multi-axis rotations
-  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitZ());
-  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
 
-  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(M_PI - 0.1F, Eigen::Vector3f::UnitZ());
-  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-M_PI + 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI - 0.1f, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-M_PI + 0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
 
-  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(M_PI + 0.1F, Eigen::Vector3f::UnitZ());
-  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-M_PI - 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI + 0.1f, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-M_PI - 0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
 
-  q_ned = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitZ());
-  q_enu = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
 
-  q_ned = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitZ());
-  q_enu = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
 
-  q_ned = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-M_PI + 0.1F, Eigen::Vector3f::UnitZ());
-  q_enu = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(M_PI - 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-M_PI + 0.1f, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(M_PI - 0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
 
-  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-M_PI - 0.1F, Eigen::Vector3f::UnitZ());
-  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(M_PI + 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-M_PI - 0.1f, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(M_PI + 0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
 
-  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitZ());
-  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeNedToEnu(q_ned));
 }
 
@@ -118,104 +118,104 @@ TEST(FrameConversion, attitudeEnuToNed) {
   quaternionsApproxEqualTest(q_enu, px4_ros2::attitudeEnuToNed(q_ned));
 
   // Test various multi-axis rotations
-  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitZ());
-  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
 
-  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(M_PI - 0.1F, Eigen::Vector3f::UnitZ());
-  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-M_PI + 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI - 0.1f, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-M_PI + 0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
 
-  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(M_PI + 0.1F, Eigen::Vector3f::UnitZ());
-  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-M_PI - 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI + 0.1f, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-M_PI - 0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
 
-  q_enu = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitZ());
-  q_ned = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
 
-  q_enu = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitZ());
-  q_ned = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
 
-  q_enu = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-M_PI + 0.1F, Eigen::Vector3f::UnitZ());
-  q_ned = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(M_PI - 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-M_PI + 0.1f, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(M_PI - 0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
 
-  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-M_PI - 0.1F, Eigen::Vector3f::UnitZ());
-  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(M_PI + 0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-M_PI - 0.1f, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(M_PI + 0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
 
-  q_enu = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitZ());
-  q_ned = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F + M_PI_2, Eigen::Vector3f::UnitZ());
+  q_enu = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitZ());
+  q_ned = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f + M_PI_2, Eigen::Vector3f::UnitZ());
   quaternionsApproxEqualTest(q_ned, px4_ros2::attitudeEnuToNed(q_enu));
 }
 
 TEST(FrameConversion, positionNedToEnu) {
-  Eigen::Vector3f v_ned(1.F, 2.F, 3.F);
-  Eigen::Vector3f v_enu(2.F, 1.F, -3.F);
+  Eigen::Vector3f v_ned(1.f, 2.f, 3.f);
+  Eigen::Vector3f v_enu(2.f, 1.f, -3.f);
   vectorsApproxEqualTest(v_enu, px4_ros2::positionNedToEnu(v_ned));
 }
 
 TEST(FrameConversion, positionEnuToNed) {
-  Eigen::Vector3f v_enu(1.F, 2.F, 3.F);
-  Eigen::Vector3f v_ned(2.F, 1.F, -3.F);
+  Eigen::Vector3f v_enu(1.f, 2.f, 3.f);
+  Eigen::Vector3f v_ned(2.f, 1.f, -3.f);
   vectorsApproxEqualTest(v_ned, px4_ros2::positionEnuToNed(v_enu));
 }
 
 TEST(FrameConversion, frdToFlu) {
-  Eigen::Vector3f v_frd(1.F, 2.F, 3.F);
-  Eigen::Vector3f v_flu(1.F, -2.F, -3.F);
+  Eigen::Vector3f v_frd(1.f, 2.f, 3.f);
+  Eigen::Vector3f v_flu(1.f, -2.f, -3.f);
   vectorsApproxEqualTest(v_flu, px4_ros2::frdToFlu(v_frd));
 }
 
 TEST(FrameConversion, fluToFrd) {
-  Eigen::Vector3f v_flu(1.F, 2.F, 3.F);
-  Eigen::Vector3f v_frd(1.F, -2.F, -3.F);
+  Eigen::Vector3f v_flu(1.f, 2.f, 3.f);
+  Eigen::Vector3f v_frd(1.f, -2.f, -3.f);
   vectorsApproxEqualTest(v_frd, px4_ros2::fluToFrd(v_flu));
 }
 
 TEST(FrameConversion, varianceNedToEnu) {
-  Eigen::Vector3f v_enu(1.F, 2.F, 3.F);
-  Eigen::Vector3f v_ned(2.F, 1.F, 3.F);
+  Eigen::Vector3f v_enu(1.f, 2.f, 3.f);
+  Eigen::Vector3f v_ned(2.f, 1.f, 3.f);
   vectorsApproxEqualTest(v_ned, px4_ros2::varianceNedToEnu(v_enu));
 }
 
 TEST(FrameConversion, varianceEnuToNed) {
-  Eigen::Vector3f v_enu(1.F, 2.F, 3.F);
-  Eigen::Vector3f v_ned(2.F, 1.F, 3.F);
+  Eigen::Vector3f v_enu(1.f, 2.f, 3.f);
+  Eigen::Vector3f v_ned(2.f, 1.f, 3.f);
   vectorsApproxEqualTest(v_ned, px4_ros2::varianceEnuToNed(v_enu));
 }
 
@@ -224,26 +224,26 @@ TEST(Geometry, yawBodyToWorld) {
   Eigen::Vector3f point_body;
   Eigen::Vector3f point_world;
 
-  yaw = 0.F;
-  point_body = Eigen::Vector3f(1.F, 2.F, 3.F);
+  yaw = 0.f;
+  point_body = Eigen::Vector3f(1.f, 2.f, 3.f);
   vectorsApproxEqualTest(point_body, px4_ros2::yawBodyToWorld(yaw, point_body));
 
   yaw = M_PI_2;
-  point_body = Eigen::Vector3f(1.F, 2.F, 3.F);
-  point_world = Eigen::Vector3f(-2.F, 1.F, 3.F);
+  point_body = Eigen::Vector3f(1.f, 2.f, 3.f);
+  point_world = Eigen::Vector3f(-2.f, 1.f, 3.f);
   vectorsApproxEqualTest(point_world, px4_ros2::yawBodyToWorld(yaw, point_body));
 
-  yaw = -3.F * M_PI / 4.F;
-  point_body = Eigen::Vector3f(1.F, 2.F, 3.F);
-  point_world = Eigen::Vector3f(std::sqrt(2) / 2, -3 / std::sqrt(2), 3.F);
+  yaw = -3.f * M_PI / 4.f;
+  point_body = Eigen::Vector3f(1.f, 2.f, 3.f);
+  point_world = Eigen::Vector3f(std::sqrt(2) / 2, -3 / std::sqrt(2), 3.f);
   vectorsApproxEqualTest(point_world, px4_ros2::yawBodyToWorld(yaw, point_body));
 
-  yaw = -M_PI_2 + 0.1F;
-  point_body = Eigen::Vector3f(1.F, 2.F, 3.F);
+  yaw = -M_PI_2 + 0.1f;
+  point_body = Eigen::Vector3f(1.f, 2.f, 3.f);
   point_world = Eigen::Vector3f(
     std::cos(yaw) * point_body.x() - std::sin(yaw) * point_body.y(),
     std::sin(yaw) * point_body.x() + std::cos(yaw) * point_body.y(),
-    3.F
+    3.f
   );
   vectorsApproxEqualTest(point_world, px4_ros2::yawBodyToWorld(yaw, point_body));
 }

--- a/px4_ros2_cpp/test/unit/utils/geometry.cpp
+++ b/px4_ros2_cpp/test/unit/utils/geometry.cpp
@@ -12,9 +12,9 @@
 TEST(Geometry, wrapPi) {
   EXPECT_NEAR(M_PI_2, px4_ros2::wrapPi(M_PI_2), 1e-3);
   EXPECT_NEAR(-M_PI_2, px4_ros2::wrapPi(-M_PI_2), 1e-3);
-  EXPECT_NEAR(0.F, px4_ros2::wrapPi(4 * M_PI), 1e-3);
-  EXPECT_NEAR(-3.F * M_PI / 4.F, px4_ros2::wrapPi(-11.F * M_PI / 4.F), 1e-3);
-  EXPECT_NEAR(3.F * M_PI / 4.F, px4_ros2::wrapPi(11.F * M_PI / 4.F), 1e-3);
+  EXPECT_NEAR(0.f, px4_ros2::wrapPi(4 * M_PI), 1e-3);
+  EXPECT_NEAR(-3.f * M_PI / 4.f, px4_ros2::wrapPi(-11.f * M_PI / 4.f), 1e-3);
+  EXPECT_NEAR(3.f * M_PI / 4.f, px4_ros2::wrapPi(11.f * M_PI / 4.f), 1e-3);
 
   // Absolute value due to floating point precision, 2*k*pi can map to -pi and pi
   EXPECT_NEAR(M_PI, std::fabs(px4_ros2::wrapPi(-11.0 * M_PI)), 1e-3);
@@ -26,69 +26,69 @@ TEST(Geometry, quaternionToEulerRPY) {
 
   // Roll
   q = Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitX());
-  v_euler = Eigen::Vector3f{M_PI_2, 0.F, 0.F};
+  v_euler = Eigen::Vector3f{M_PI_2, 0.f, 0.f};
   vectorsApproxEqualTest(v_euler, px4_ros2::quaternionToEulerRPY(q), "roll pi/2");
 
   // Pitch
-  q = Eigen::AngleAxisf(-M_PI / 4.F, Eigen::Vector3f::UnitY());
-  v_euler = Eigen::Vector3f{0.F, -M_PI / 4.F, 0.F};
+  q = Eigen::AngleAxisf(-M_PI / 4.f, Eigen::Vector3f::UnitY());
+  v_euler = Eigen::Vector3f{0.f, -M_PI / 4.f, 0.f};
   vectorsApproxEqualTest(v_euler, px4_ros2::quaternionToEulerRPY(q), "pitch -pi/4");
 
   // Yaw
-  q = Eigen::AngleAxisf(3.F * M_PI / 4.F, Eigen::Vector3f::UnitZ());
-  v_euler = Eigen::Vector3f{0.F, 0.F, 3.F * M_PI / 4.F};
+  q = Eigen::AngleAxisf(3.f * M_PI / 4.f, Eigen::Vector3f::UnitZ());
+  v_euler = Eigen::Vector3f{0.f, 0.f, 3.f * M_PI / 4.f};
   vectorsApproxEqualTest(v_euler, px4_ros2::quaternionToEulerRPY(q), "yaw 3pi/4");
 
   // Gimbal lock cases
   q = Eigen::AngleAxisf(-M_PI_2, Eigen::Vector3f::UnitY());
-  v_euler = Eigen::Vector3f{0.F, -M_PI_2, 0.F};
+  v_euler = Eigen::Vector3f{0.f, -M_PI_2, 0.f};
   vectorsApproxEqualTest(v_euler, px4_ros2::quaternionToEulerRPY(q), "gimbal lock: pitch -pi/2");
 
   q = Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitY());
-  v_euler = Eigen::Vector3f{0.F, M_PI_2, 0.F};
+  v_euler = Eigen::Vector3f{0.f, M_PI_2, 0.f};
   vectorsApproxEqualTest(v_euler, px4_ros2::quaternionToEulerRPY(q), "gimbal lock: pitch pi/2");
 
   // Multi-axis rotations have multiple euler angle representations
   // Therefore we convert euler angle back to quaternion and compare to that
 
-  q = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitZ());
+  q = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitZ());
   quaternionToEulerReconstructionTest(q);
 
-  q = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(M_PI - 0.1F, Eigen::Vector3f::UnitZ());
+  q = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI - 0.1f, Eigen::Vector3f::UnitZ());
   quaternionToEulerReconstructionTest(q);
 
-  q = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(M_PI + 0.1F, Eigen::Vector3f::UnitZ());
+  q = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(M_PI + 0.1f, Eigen::Vector3f::UnitZ());
   quaternionToEulerReconstructionTest(q);
 
-  q = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitZ());
+  q = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitZ());
   quaternionToEulerReconstructionTest(q);
 
-  q = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitZ());
+  q = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitZ());
   quaternionToEulerReconstructionTest(q);
 
-  q = Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-M_PI + 0.1F, Eigen::Vector3f::UnitZ());
+  q = Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-M_PI + 0.1f, Eigen::Vector3f::UnitZ());
   quaternionToEulerReconstructionTest(q);
 
-  q = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-M_PI - 0.1F, Eigen::Vector3f::UnitZ());
+  q = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-M_PI - 0.1f, Eigen::Vector3f::UnitZ());
   quaternionToEulerReconstructionTest(q);
 
-  q = Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitX()) *
-    Eigen::AngleAxisf(0.1F, Eigen::Vector3f::UnitY()) *
-    Eigen::AngleAxisf(-0.1F, Eigen::Vector3f::UnitZ());
+  q = Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitX()) *
+    Eigen::AngleAxisf(0.1f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(-0.1f, Eigen::Vector3f::UnitZ());
   quaternionToEulerReconstructionTest(q);
 }
 
@@ -102,9 +102,9 @@ TEST(Geometry, quaternionToRoll) {
   EXPECT_NEAR(roll, px4_ros2::quaternionToRoll(q), 1e-3);
 
   // Rolled -45 deg along Y-axis
-  q = Eigen::AngleAxisf(-M_PI / 4.F, Eigen::Vector3f::UnitY()) *
+  q = Eigen::AngleAxisf(-M_PI / 4.f, Eigen::Vector3f::UnitY()) *
     Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitZ());
-  roll = -M_PI / 4.F;
+  roll = -M_PI / 4.f;
   EXPECT_NEAR(roll, px4_ros2::quaternionToRoll(q), 1e-3);
 }
 
@@ -118,9 +118,9 @@ TEST(Geometry, quaternionToPitch) {
   EXPECT_NEAR(pitch, px4_ros2::quaternionToPitch(q), 1e-3);
 
   // Rolled -45 deg along Y-axis
-  q = Eigen::AngleAxisf(-M_PI / 4.F, Eigen::Vector3f::UnitY()) *
+  q = Eigen::AngleAxisf(-M_PI / 4.f, Eigen::Vector3f::UnitY()) *
     Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitZ());
-  pitch = 0.F;
+  pitch = 0.f;
   EXPECT_NEAR(pitch, px4_ros2::quaternionToPitch(q), 1e-3);
 }
 
@@ -134,7 +134,7 @@ TEST(Geometry, quaternionToYaw) {
   EXPECT_NEAR(yaw, px4_ros2::quaternionToYaw(q), 1e-3);
 
   // Rolled -45 deg along Y-axis
-  q = Eigen::AngleAxisf(-M_PI / 4.F, Eigen::Vector3f::UnitY()) *
+  q = Eigen::AngleAxisf(-M_PI / 4.f, Eigen::Vector3f::UnitY()) *
     Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitZ());
   yaw = M_PI_2;
   EXPECT_NEAR(yaw, px4_ros2::quaternionToYaw(q), 1e-3);


### PR DESCRIPTION
The original intent behind the check was only for L, as l is similar to 1.
https://clang.llvm.org/extra/clang-tidy/checks/readability/uppercase-literal-suffix.html

And some other clang-tidy changes:
- ignore very verbose misc-include-cleaner
- message_compatibility_check: move static methods to anonymous namespace