### PR TITLE
Add fw attitude example

### DIFF
--- a/examples/cpp/modes/fw_attitude/CMakeLists.txt
+++ b/examples/cpp/modes/fw_attitude/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.5)
+project(example_mode_fw_attitude_cpp)
+
+if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter)
+endif()
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(px4_ros2_cpp REQUIRED)
+
+include_directories(include ${Eigen3_INCLUDE_DIRS})
+add_executable(example_mode_fw_attitude
+        src/main.cpp)
+ament_target_dependencies(example_mode_fw_attitude px4_ros2_cpp rclcpp)
+
+install(TARGETS
+        example_mode_fw_attitude
+        DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+    find_package(ament_lint_auto REQUIRED)
+    ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/examples/cpp/modes/fw_attitude/include/mode.hpp
+++ b/examples/cpp/modes/fw_attitude/include/mode.hpp
@@ -1,0 +1,67 @@
+/****************************************************************************
+ * Copyright (c) 2023 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+#pragma once
+
+#include <cmath>
+
+#include <px4_ros2/components/mode.hpp>
+#include <px4_ros2/control/setpoint_types/experimental/attitude.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+
+static const std::string kName = "FW Attitude Example";
+static const std::string kNodeName = "example_mode_fw_attitude";
+
+class FwAttModeTest : public px4_ros2::ModeBase
+{
+public:
+  explicit FwAttModeTest(rclcpp::Node & node)
+  : ModeBase(node, kName)
+  {
+    _att_setpoint = std::make_shared<px4_ros2::AttitudeSetpointType>(*this);
+
+  }
+
+  void onActivate() override {}
+
+  void onDeactivate() override {}
+
+  void updateSetpoint(float dt_s) override
+  {
+    // Setting constant angles and thrust.
+    _att_setpoint->update(-25.f * M_PI / 180.f, 2.2f * M_PI / 180.f, 0.f, {0.27f, 0.f, 0.f});
+
+  }
+
+private:
+  std::shared_ptr<px4_ros2::AttitudeSetpointType> _att_setpoint;
+
+};
+
+class TestNode : public rclcpp::Node
+{
+public:
+  TestNode()
+  : Node(kNodeName)
+  {
+    // Enable debug output
+    auto ret =
+      rcutils_logging_set_logger_level(get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
+
+    if (ret != RCUTILS_RET_OK) {
+      RCLCPP_ERROR(get_logger(), "Error setting severity: %s", rcutils_get_error_string().str);
+      rcutils_reset_error();
+    }
+
+    _mode = std::make_unique<FwAttModeTest>(*this);
+
+    if (!_mode->doRegister()) {
+      throw std::runtime_error("Registration failed");
+    }
+  }
+
+private:
+  std::unique_ptr<FwAttModeTest> _mode;
+};

--- a/examples/cpp/modes/fw_attitude/package.xml
+++ b/examples/cpp/modes/fw_attitude/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>example_mode_fw_attitude_cpp</name>
+  <version>0.0.1</version>
+  <description>Example mode: FW Attitude</description>
+  <maintainer email="beat-kueng@gmx.net">Beat Kueng</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
+
+  <build_depend>eigen</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_export_depend>eigen</build_export_depend>
+
+  <depend>px4_ros2_cpp</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/examples/cpp/modes/fw_attitude/src/main.cpp
+++ b/examples/cpp/modes/fw_attitude/src/main.cpp
@@ -1,0 +1,17 @@
+/****************************************************************************
+ * Copyright (c) 2024 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#include "rclcpp/rclcpp.hpp"
+
+#include <mode.hpp>
+
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<TestNode>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/attitude.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/attitude.hpp
@@ -27,7 +27,7 @@ public:
   float desiredUpdateRateHz() override {return 200.f;}
 
   void update(
-    const Eigen::Quaternionf & attidude_setpoint,
+    const Eigen::Quaternionf & attitude_setpoint,
     const Eigen::Vector3f & thrust_setpoint_frd, float yaw_sp_move_rate_rad_s = 0.f);
 
 private:

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/attitude.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/attitude.hpp
@@ -30,6 +30,20 @@ public:
     const Eigen::Quaternionf & attitude_setpoint,
     const Eigen::Vector3f & thrust_setpoint_frd, float yaw_sp_move_rate_rad_s = 0.f);
 
+  /**
+   * @brief Send an attitude setpoint to the flight controller.
+   * Euler angles follow the RPY extrinsic Tait-Bryan convention (equiv. YPR intrinsic)
+   *
+   * @param roll Attitude setpoint roll angle [rad]
+   * @param pitch Attitude setpoint pitch angle [rad]
+   * @param yaw Attitude setpoint yaw angle [rad]
+   * @param thrust_setpoint_body Throttle demand [-1, 1]^3
+   * @param yaw_sp_move_rate_rad_s Yaw setpoint move rate [rad/s]
+  */
+  void update(
+    float roll, float pitch, float yaw,
+    const Eigen::Vector3f & thrust_setpoint_body, float yaw_sp_move_rate_rad_s = 0.f);
+
 private:
   rclcpp::Node & _node;
   rclcpp::Publisher<px4_msgs::msg::VehicleAttitudeSetpoint>::SharedPtr

--- a/px4_ros2_cpp/include/px4_ros2/utils/geometry.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/geometry.hpp
@@ -51,7 +51,7 @@ Type wrapPi(Type angle)
  * XYZ axes correspond to RPY angles respectively.
  *
  * @param q The input quaternion.
- * @return Euler angles corresponding to the given quaternion in range R, P, Y = [-pi, pi], [-pi/2, pi], [-pi, pi].
+ * @return Euler angles corresponding to the given quaternion in range R, P, Y = [-pi, pi], [-pi/2, pi/2], [-pi, pi].
  */
 template<typename Type>
 Eigen::Matrix<Type, 3, 1> quaternionToEulerRpy(const Eigen::Quaternion<Type> & q)

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/attitude.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/attitude.cpp
@@ -18,17 +18,17 @@ AttitudeSetpointType::AttitudeSetpointType(Context & context)
 }
 
 void AttitudeSetpointType::update(
-  const Eigen::Quaternionf & attidude_setpoint,
+  const Eigen::Quaternionf & attitude_setpoint,
   const Eigen::Vector3f & thrust_setpoint_frd,
   float yaw_sp_move_rate_rad_s)
 {
   onUpdate();
 
   px4_msgs::msg::VehicleAttitudeSetpoint sp{};
-  sp.q_d[0] = attidude_setpoint.w();
-  sp.q_d[1] = attidude_setpoint.x();
-  sp.q_d[2] = attidude_setpoint.y();
-  sp.q_d[3] = attidude_setpoint.z();
+  sp.q_d[0] = attitude_setpoint.w();
+  sp.q_d[1] = attitude_setpoint.x();
+  sp.q_d[2] = attitude_setpoint.y();
+  sp.q_d[3] = attitude_setpoint.z();
   sp.thrust_body[0] = thrust_setpoint_frd(0);
   sp.thrust_body[1] = thrust_setpoint_frd(1);
   sp.thrust_body[2] = thrust_setpoint_frd(2);


### PR DESCRIPTION
Updated setpoint type attitude to update with euler angles instead of quaternions only.
Set small fixed attitude setpoint example for constant banking to show interface for FW