### PR TITLE
components: add NodeWithMode class

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -523,7 +523,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,

--- a/examples/cpp/modes/fw_attitude/include/mode.hpp
+++ b/examples/cpp/modes/fw_attitude/include/mode.hpp
@@ -12,7 +12,6 @@
 #include <rclcpp/rclcpp.hpp>
 
 static const std::string kName = "FW Attitude Example";
-static const std::string kNodeName = "example_mode_fw_attitude";
 
 class FwAttModeTest : public px4_ros2::ModeBase
 {
@@ -38,30 +37,4 @@ public:
 private:
   std::shared_ptr<px4_ros2::AttitudeSetpointType> _att_setpoint;
 
-};
-
-class TestNode : public rclcpp::Node
-{
-public:
-  TestNode()
-  : Node(kNodeName)
-  {
-    // Enable debug output
-    auto ret =
-      rcutils_logging_set_logger_level(get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-
-    if (ret != RCUTILS_RET_OK) {
-      RCLCPP_ERROR(get_logger(), "Error setting severity: %s", rcutils_get_error_string().str);
-      rcutils_reset_error();
-    }
-
-    _mode = std::make_unique<FwAttModeTest>(*this);
-
-    if (!_mode->doRegister()) {
-      throw std::runtime_error("Registration failed");
-    }
-  }
-
-private:
-  std::unique_ptr<FwAttModeTest> _mode;
 };

--- a/examples/cpp/modes/fw_attitude/src/main.cpp
+++ b/examples/cpp/modes/fw_attitude/src/main.cpp
@@ -6,12 +6,17 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <mode.hpp>
+#include <px4_ros2/components/node_with_mode.hpp>
 
+using MyNodeWithMode = px4_ros2::NodeWithMode<FwAttModeTest>;
+
+static const std::string kNodeName = "example_mode_fw_attitude";
+static const bool kEnableDebugOutput = true;
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<TestNode>());
+  rclcpp::spin(std::make_shared<MyNodeWithMode>(kNodeName, kEnableDebugOutput));
   rclcpp::shutdown();
   return 0;
 }

--- a/examples/cpp/modes/goto/include/mode.hpp
+++ b/examples/cpp/modes/goto/include/mode.hpp
@@ -15,7 +15,6 @@
 #include <algorithm>
 
 static const std::string kName = "Go-to Example";
-static const std::string kNodeName = "example_mode_goto";
 
 using namespace px4_ros2::literals; // NOLINT
 
@@ -194,30 +193,4 @@ private:
     const float heading_error_wrapped = px4_ros2::wrapPi(target_heading_rad - _vehicle_heading_rad);
     return fabsf(heading_error_wrapped) < kHeadingErrorThreshold;
   }
-};
-
-class TestNode : public rclcpp::Node
-{
-public:
-  TestNode()
-  : Node(kNodeName)
-  {
-    // Enable debug output
-    auto ret =
-      rcutils_logging_set_logger_level(get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-
-    if (ret != RCUTILS_RET_OK) {
-      RCLCPP_ERROR(get_logger(), "Error setting severity: %s", rcutils_get_error_string().str);
-      rcutils_reset_error();
-    }
-
-    _mode = std::make_unique<FlightModeTest>(*this);
-
-    if (!_mode->doRegister()) {
-      throw std::runtime_error("Registration failed");
-    }
-  }
-
-private:
-  std::unique_ptr<FlightModeTest> _mode;
 };

--- a/examples/cpp/modes/goto/src/main.cpp
+++ b/examples/cpp/modes/goto/src/main.cpp
@@ -6,12 +6,17 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <mode.hpp>
+#include <px4_ros2/components/node_with_mode.hpp>
 
+using MyNodeWithMode = px4_ros2::NodeWithMode<FlightModeTest>;
+
+static const std::string kNodeName = "example_mode_goto";
+static const bool kEnableDebugOutput = true;
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<TestNode>());
+  rclcpp::spin(std::make_shared<MyNodeWithMode>(kNodeName, kEnableDebugOutput));
   rclcpp::shutdown();
   return 0;
 }

--- a/examples/cpp/modes/goto_global/include/mode.hpp
+++ b/examples/cpp/modes/goto_global/include/mode.hpp
@@ -16,7 +16,6 @@
 #include <algorithm>
 
 static const std::string kName = "Go-to Global Example";
-static const std::string kNodeName = "example_mode_goto_global";
 
 using namespace px4_ros2::literals; // NOLINT
 
@@ -195,30 +194,4 @@ private:
     const float heading_error_wrapped = px4_ros2::wrapPi(target_heading_rad - _vehicle_heading_rad);
     return fabsf(heading_error_wrapped) < kHeadingErrorThreshold;
   }
-};
-
-class TestNode : public rclcpp::Node
-{
-public:
-  TestNode()
-  : Node(kNodeName)
-  {
-    // Enable debug output
-    auto ret =
-      rcutils_logging_set_logger_level(get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-
-    if (ret != RCUTILS_RET_OK) {
-      RCLCPP_ERROR(get_logger(), "Error setting severity: %s", rcutils_get_error_string().str);
-      rcutils_reset_error();
-    }
-
-    _mode = std::make_unique<FlightModeTest>(*this);
-
-    if (!_mode->doRegister()) {
-      throw std::runtime_error("Registration failed");
-    }
-  }
-
-private:
-  std::unique_ptr<FlightModeTest> _mode;
 };

--- a/examples/cpp/modes/goto_global/src/main.cpp
+++ b/examples/cpp/modes/goto_global/src/main.cpp
@@ -6,12 +6,17 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <mode.hpp>
+#include <px4_ros2/components/node_with_mode.hpp>
 
+using MyNodeWithMode = px4_ros2::NodeWithMode<FlightModeTest>;
+
+static const std::string kNodeName = "example_mode_goto_global";
+static const bool kEnableDebugOutput = true;
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<TestNode>());
+  rclcpp::spin(std::make_shared<MyNodeWithMode>(kNodeName, kEnableDebugOutput));
   rclcpp::shutdown();
   return 0;
 }

--- a/examples/cpp/modes/manual/include/mode.hpp
+++ b/examples/cpp/modes/manual/include/mode.hpp
@@ -17,7 +17,6 @@
 using namespace std::chrono_literals; // NOLINT
 
 static const std::string kName = "My Manual Mode";
-static const std::string kNodeName = "example_mode_manual";
 
 class FlightModeTest : public px4_ros2::ModeBase
 {
@@ -73,30 +72,4 @@ private:
   std::shared_ptr<px4_ros2::AttitudeSetpointType> _attitude_setpoint;
   std::shared_ptr<px4_ros2::PeripheralActuatorControls> _peripheral_actuator_controls;
   float _yaw{0.f};
-};
-
-class TestNode : public rclcpp::Node
-{
-public:
-  TestNode()
-  : Node(kNodeName)
-  {
-    // Enable debug output
-    auto ret =
-      rcutils_logging_set_logger_level(get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-
-    if (ret != RCUTILS_RET_OK) {
-      RCLCPP_ERROR(get_logger(), "Error setting severity: %s", rcutils_get_error_string().str);
-      rcutils_reset_error();
-    }
-
-    _mode = std::make_unique<FlightModeTest>(*this);
-
-    if (!_mode->doRegister()) {
-      throw std::runtime_error("Registration failed");
-    }
-  }
-
-private:
-  std::unique_ptr<FlightModeTest> _mode;
 };

--- a/examples/cpp/modes/manual/src/main.cpp
+++ b/examples/cpp/modes/manual/src/main.cpp
@@ -6,12 +6,17 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <mode.hpp>
+#include <px4_ros2/components/node_with_mode.hpp>
 
+using MyNodeWithMode = px4_ros2::NodeWithMode<FlightModeTest>;
+
+static const std::string kNodeName = "example_mode_manual";
+static const bool kEnableDebugOutput = true;
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<TestNode>());
+  rclcpp::spin(std::make_shared<MyNodeWithMode>(kNodeName, kEnableDebugOutput));
   rclcpp::shutdown();
   return 0;
 }

--- a/examples/cpp/modes/mode_with_executor/include/mode.hpp
+++ b/examples/cpp/modes/mode_with_executor/include/mode.hpp
@@ -16,7 +16,6 @@
 using namespace std::chrono_literals; // NOLINT
 
 static const std::string kName = "Autonomous Executor";
-static const std::string kNodeName = "example_mode_with_executor";
 
 class FlightModeTest : public px4_ros2::ModeBase
 {
@@ -123,36 +122,4 @@ public:
 
 private:
   rclcpp::Node & _node;
-};
-
-class TestNode : public rclcpp::Node
-{
-public:
-  TestNode()
-  : Node(kNodeName)
-  {
-    // Enable debug output
-    auto ret =
-      rcutils_logging_set_logger_level(get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-
-    if (ret != RCUTILS_RET_OK) {
-      RCLCPP_ERROR(get_logger(), "Error setting severity: %s", rcutils_get_error_string().str);
-      rcutils_reset_error();
-    }
-
-    if (!px4_ros2::waitForFMU(*this)) {
-      throw std::runtime_error("No message from FMU");
-    }
-
-    _mode = std::make_unique<FlightModeTest>(*this);
-    _mode_executor = std::make_unique<ModeExecutorTest>(*this, *_mode);
-
-    if (!_mode_executor->doRegister()) {
-      throw std::runtime_error("Registration failed");
-    }
-  }
-
-private:
-  std::unique_ptr<FlightModeTest> _mode;
-  std::unique_ptr<ModeExecutorTest> _mode_executor;
 };

--- a/examples/cpp/modes/mode_with_executor/src/main.cpp
+++ b/examples/cpp/modes/mode_with_executor/src/main.cpp
@@ -6,12 +6,17 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <mode.hpp>
+#include <px4_ros2/components/node_with_mode.hpp>
 
+using MyNodeWithModeExecutor = px4_ros2::NodeWithModeExecutor<ModeExecutorTest, FlightModeTest>;
+
+static const std::string kNodeName = "example_mode_with_executor";
+static const bool kEnableDebugOutput = true;
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<TestNode>());
+  rclcpp::spin(std::make_shared<MyNodeWithModeExecutor>(kNodeName, kEnableDebugOutput));
   rclcpp::shutdown();
   return 0;
 }

--- a/examples/cpp/modes/rtl_replacement/include/mode.hpp
+++ b/examples/cpp/modes/rtl_replacement/include/mode.hpp
@@ -17,7 +17,6 @@
 using namespace std::chrono_literals; // NOLINT
 
 static const std::string kName = "Custom RTL";
-static const std::string kNodeName = "example_mode_rtl";
 
 class FlightModeTest : public px4_ros2::ModeBase
 {
@@ -58,30 +57,4 @@ private:
   bool _landed{true};
   rclcpp::Subscription<px4_msgs::msg::VehicleLandDetected>::SharedPtr _vehicle_land_detected_sub;
   std::shared_ptr<px4_ros2::TrajectorySetpointType> _trajectory_setpoint;
-};
-
-class TestNode : public rclcpp::Node
-{
-public:
-  TestNode()
-  : Node(kNodeName)
-  {
-    // Enable debug output
-    auto ret =
-      rcutils_logging_set_logger_level(get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
-
-    if (ret != RCUTILS_RET_OK) {
-      RCLCPP_ERROR(get_logger(), "Error setting severity: %s", rcutils_get_error_string().str);
-      rcutils_reset_error();
-    }
-
-    _mode = std::make_unique<FlightModeTest>(*this);
-
-    if (!_mode->doRegister()) {
-      throw std::runtime_error("Registration failed");
-    }
-  }
-
-private:
-  std::unique_ptr<FlightModeTest> _mode;
 };

--- a/examples/cpp/modes/rtl_replacement/src/main.cpp
+++ b/examples/cpp/modes/rtl_replacement/src/main.cpp
@@ -6,12 +6,17 @@
 #include "rclcpp/rclcpp.hpp"
 
 #include <mode.hpp>
+#include <px4_ros2/components/node_with_mode.hpp>
 
+using MyNodeWithMode = px4_ros2::NodeWithMode<FlightModeTest>;
+
+static const std::string kNodeName = "example_mode_rtl";
+static const bool kEnableDebugOutput = true;
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<TestNode>());
+  rclcpp::spin(std::make_shared<MyNodeWithMode>(kNodeName, kEnableDebugOutput));
   rclcpp::shutdown();
   return 0;
 }

--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -30,6 +30,7 @@ set(HEADER_FILES
         include/px4_ros2/components/message_compatibility_check.hpp
         include/px4_ros2/components/mode.hpp
         include/px4_ros2/components/mode_executor.hpp
+        include/px4_ros2/components/node_with_mode.hpp
         include/px4_ros2/components/overrides.hpp
         include/px4_ros2/components/wait_for_fmu.hpp
         include/px4_ros2/control/peripheral_actuators.hpp

--- a/px4_ros2_cpp/include/px4_ros2/components/node_with_mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/node_with_mode.hpp
@@ -1,0 +1,129 @@
+/****************************************************************************
+ * Copyright (c) 2024 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#pragma once
+
+#include <rclcpp/rclcpp.hpp>
+#include <px4_ros2/components/mode.hpp>
+#include <px4_ros2/components/wait_for_fmu.hpp>
+
+namespace px4_ros2
+{
+/** \ingroup components
+ *  @{
+ */
+
+/**
+ * @brief A ROS2 node which instantiates a control mode and handles its registration with PX4.
+ * @tparam ModeT The mode type, which must be derived from px4_ros2::ModeBase.
+ *
+ * Example usage:
+ *
+ * @code{.cpp}
+ * class MyMode : public px4_ros2::ModeBase {...};
+ * rclcpp::spin(std::make_shared<px4_ros2::NodeWithMode<MyMode>>("my_node"));
+ * @endcode
+ *
+ * @ingroup components
+ */
+template<typename ModeT>
+class NodeWithMode : public rclcpp::Node
+{
+  static_assert(
+    std::is_base_of<ModeBase, ModeT>::value,
+    "Template type ModeT must be derived from px4_ros2::ModeBase");
+
+public:
+  explicit NodeWithMode(std::string node_name, bool enable_debug_output = false)
+  : Node(node_name)
+  {
+    if (enable_debug_output) {
+      auto ret =
+        rcutils_logging_set_logger_level(get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
+
+      if (ret != RCUTILS_RET_OK) {
+        RCLCPP_ERROR(get_logger(), "Error setting severity: %s", rcutils_get_error_string().str);
+        rcutils_reset_error();
+      }
+    }
+
+    _mode = std::make_unique<ModeT>(*this);
+
+    if (!_mode->doRegister()) {
+      throw std::runtime_error("Registration failed");
+    }
+  }
+
+  ModeT & getMode() const
+  {
+    return *_mode;
+  }
+
+private:
+  std::unique_ptr<ModeT> _mode;
+};
+
+/**
+ * @brief A ROS2 node which instantiates a mode executor and its owned mode, and handles their registration with PX4.
+ *
+ * Assumes mode executor constructor signature is `ModeExecutorT(rclcpp::Node, ModeT)`.
+ *
+ * @tparam ModeExecutorT The mode executor type, which must be derived from px4_ros2::ModeExecutorBase.
+ * @tparam ModeT The mode type owned by the executor, which must be derived from px4_ros2::ModeBase.
+ *
+ * Example usage:
+ *
+ * @code{.cpp}
+ * class MyMode : public px4_ros2::ModeBase {...};
+ * class MyExecutor : public px4_ros2::ModeExecutor {...};
+ * rclcpp::spin(std::make_shared<px4_ros2::NodeWithMode<MyExecutor, MyMode>>("my_node"));
+ * @endcode
+ *
+ * @ingroup components
+ */
+template<typename ModeExecutorT, typename ModeT>
+class NodeWithModeExecutor : public rclcpp::Node
+{
+  static_assert(
+    std::is_base_of<ModeExecutorBase, ModeExecutorT>::value,
+    "Template type ModeExecutorT must be derived from px4_ros2::ModeExecutorBase");
+  static_assert(
+    std::is_base_of<ModeBase, ModeT>::value,
+    "Template type ModeT must be derived from px4_ros2::ModeBase");
+
+public:
+  explicit NodeWithModeExecutor(std::string node_name, bool enable_debug_output = false)
+  : Node(node_name)
+  {
+    if (enable_debug_output) {
+      auto ret =
+        rcutils_logging_set_logger_level(get_logger().get_name(), RCUTILS_LOG_SEVERITY_DEBUG);
+
+      if (ret != RCUTILS_RET_OK) {
+        RCLCPP_ERROR(get_logger(), "Error setting severity: %s", rcutils_get_error_string().str);
+        rcutils_reset_error();
+      }
+    }
+
+    _mode = std::make_unique<ModeT>(*this);
+    _mode_executor = std::make_unique<ModeExecutorT>(*this, *_mode);
+
+    if (!_mode_executor->doRegister()) {
+      throw std::runtime_error("Registration failed");
+    }
+  }
+
+  ModeT & getMode() const
+  {
+    return *_mode;
+  }
+
+private:
+  std::unique_ptr<ModeExecutorT> _mode_executor;
+  std::unique_ptr<ModeT> _mode;
+};
+
+/** @}*/
+}  // namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/utils/frame_conversion.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/frame_conversion.hpp
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  ****************************************************************************/
 
+/**
+ * @defgroup frame_conversion Frame Conversion
+ * @ingroup utils
+ * This group contains helper functions to switch between reference frames.
+ */
+
 #pragma once
 
 #include <Eigen/Eigen>
@@ -10,6 +16,9 @@
 
 namespace px4_ros2
 {
+/** \ingroup frame_conversion
+ *  @{
+ */
 
 /**
  * @brief Converts attitude from NED to ENU frame.
@@ -176,4 +185,5 @@ static inline Eigen::Matrix<T, 3, 1> varianceEnuToNed(const Eigen::Matrix<T, 3, 
   return {v_enu.y(), v_enu.x(), v_enu.z()};
 }
 
+/** @}*/
 }  // namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/utils/geodesic.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/geodesic.hpp
@@ -3,6 +3,20 @@
  * SPDX-License-Identifier: BSD-3-Clause
  ****************************************************************************/
 
+/**
+ * @defgroup geodesic Geodesic
+ * @ingroup utils
+ *
+ * This group contains helper functions to convert points between
+ * the geographical coordinate system ("global") and the local azimuthal
+ * equidistant plane ("local"). Additionaly it provides methods for commonly
+ * used geodesic operations.
+ *
+ * Latitude and longitude are in degrees (degrees: 8.1234567°, not 81234567°).
+ * Altitude is in meters in the above mean sea level (AMSL) frame.
+ * Heading is in radians starting North going clockwise.
+ */
+
 #pragma once
 
 #include <cmath>
@@ -13,9 +27,22 @@
 
 namespace px4_ros2
 {
+/** \ingroup geodesic
+ *  @{
+ */
 
 class MapProjectionImpl;
 
+/**
+ * @brief Provides methods to convert between the geographical coordinate system ("global")
+ * and the local azimuthal equidistant plane ("local").
+ *
+ * This class handles ROS2 subscription and initializing the map projection reference point from PX4.
+ * The mathematical implementation is contained in `px4_ros2::MapProjectionImpl`.
+ *
+ * @see px4_ros2::MapProjectionImpl
+ * @ingroup geodesic
+ */
 class MapProjection
 {
 public:
@@ -29,38 +56,38 @@ public:
   bool isInitialized() const;
 
   /**
-   * Transform a point in the geographic coordinate system to the local
+   * @brief Transform a point in the geographic coordinate system to the local
    * azimuthal equidistant plane using the projection
    *
-   * @param global_position lat [deg], lon [deg] (degrees: 8.1234567°, not 81234567°)
+   * @param global_position lat [deg], lon [deg]
    * @return the point in local coordinates as north, east [m]
    */
   Eigen::Vector2f globalToLocal(const Eigen::Vector2d & global_position) const;
 
   /**
-   * Transform a point in the geographic coordinate system to the local
+   * @brief Transform a point in the geographic coordinate system to the local
    * azimuthal equidistant plane using the projection
    *
-   * @param global_position lat [deg], lon [deg], alt AMSL [m] (degrees: 8.1234567°, not 81234567°)
+   * @param global_position lat [deg], lon [deg], alt AMSL [m]
    * @return the point in local coordinates as north, east, down [m]
    */
   Eigen::Vector3f globalToLocal(const Eigen::Vector3d & global_position) const;
 
   /**
-   * Transform a point in the local azimuthal equidistant plane to the
+   * @brief Transform a point in the local azimuthal equidistant plane to the
    * geographic coordinate system using the projection
    *
    * @param local_position north, east [m]
-   * @return the point in geographic coordinates as lat [deg], lon [deg] (degrees: 8.1234567°, not 81234567°)
+   * @return the point in geographic coordinates as lat [deg], lon [deg]
    */
   Eigen::Vector2d localToGlobal(const Eigen::Vector2f & local_position) const;
 
   /**
-   * Transform a point in the local azimuthal equidistant plane to the
+   * @brief Transform a point in the local azimuthal equidistant plane to the
    * geographic coordinate system using the projection
    *
    * @param local_position north, east, down [m]
-   * @return the point in geographic coordinates as lat [deg], lon [deg], alt AMSL [m] (degrees: 8.1234567°, not 81234567°)
+   * @return the point in geographic coordinates as lat [deg], lon [deg], alt AMSL [m]
    */
   Eigen::Vector3d localToGlobal(const Eigen::Vector3f & local_position) const;
 
@@ -71,7 +98,7 @@ private:
   void assertInitalized() const;
 
   /**
-   * Callback for VehicleLocalPosition messages which intializes and updates the map projection reference point from PX4
+   * @brief Callback for VehicleLocalPosition messages which intializes and updates the map projection reference point from PX4
    *
    * @param msg the VehicleLocalPosition message
   */
@@ -83,22 +110,26 @@ private:
 };
 
 /**
- * Compute the horizontal distance between two global positions in meters.
+ * @brief Compute the horizontal distance between two global positions in meters.
  *
- * @param global_position_now current lat [deg], lon [deg] (47.1234567°, not 471234567°)
- * @param global_position_next next lat [deg], lon [deg] (8.1234567°, not 81234567°)
+ * @param global_position_now current lat [deg], lon [deg]
+ * @param global_position_next next lat [deg], lon [deg]
  * @return the horizontal distance [m] between both positions
+ *
+ * @ingroup geodesic
  */
 float horizontalDistanceToGlobalPosition(
   const Eigen::Vector2d & global_position_now,
   const Eigen::Vector2d & global_position_next);
 
 /**
- * Compute the horizontal distance between two global positions in meters.
+ * @brief Compute the horizontal distance between two global positions in meters.
  *
- * @param global_position_now current lat [deg], lon [deg], alt AMSL [m] (47.1234567°, not 471234567°)
- * @param global_position_next next lat [deg], lon [deg], alt AMSL [m] (8.1234567°, not 81234567°)
+ * @param global_position_now current lat [deg], lon [deg], alt AMSL [m]
+ * @param global_position_next next lat [deg], lon [deg], alt AMSL [m]
  * @return the horizontal distance [m] between both positions
+
+ * @ingroup geodesic
  */
 static inline float horizontalDistanceToGlobalPosition(
   const Eigen::Vector3d & global_position_now,
@@ -110,33 +141,39 @@ static inline float horizontalDistanceToGlobalPosition(
 }
 
 /**
- * Compute the distance between two global positions in meters.
+ * @brief Compute the distance between two global positions in meters.
  *
- * @param global_position_now current lat [deg], lon [deg] (47.1234567°, not 471234567°)
- * @param global_position_next next lat [deg], lon [deg] (8.1234567°, not 81234567°)
+ * @param global_position_now current lat [deg], lon [deg]
+ * @param global_position_next next lat [deg], lon [deg]
  * @return the distance [m] between both positions
+
+ * @ingroup geodesic
  */
 float distanceToGlobalPosition(
   const Eigen::Vector3d & global_position_now,
   const Eigen::Vector3d & global_position_next);
 
 /**
- * Compute the heading to the next global position in radians.
+ * @brief Compute the heading to the next global position in radians.
  *
- * @param global_position_now current lat [deg], lon [deg] (47.1234567°, not 471234567°)
- * @param global_position_next next lat [deg], lon [deg] (8.1234567°, not 81234567°)
+ * @param global_position_now current lat [deg], lon [deg]
+ * @param global_position_next next lat [deg], lon [deg]
  * @return the heading [rad] to the next global position (clockwise)
+ *
+ * @ingroup geodesic
 */
 float headingToGlobalPosition(
   const Eigen::Vector2d & global_position_now,
   const Eigen::Vector2d & global_position_next);
 
 /**
- * Compute the heading to the next global position in radians.
+ * @brief Compute the heading to the next global position in radians.
  *
- * @param global_position_now current lat [deg], lon [deg], alt AMSL [m] (47.1234567°, not 471234567°)
- * @param global_position_next next lat [deg], lon [deg], alt AMSL [m] (8.1234567°, not 81234567°)
+ * @param global_position_now current lat [deg], lon [deg], alt AMSL [m]
+ * @param global_position_next next lat [deg], lon [deg], alt AMSL [m]
  * @return the heading [rad] to the next global position (clockwise)
+ *
+ * @ingroup geodesic
 */
 static inline float headingToGlobalPosition(
   const Eigen::Vector3d & global_position_now,
@@ -148,22 +185,26 @@ static inline float headingToGlobalPosition(
 }
 
 /**
- * Compute the vector to the next global position in meters.
+ * @brief Compute the vector to the next global position in meters.
  *
- * @param global_position_now current lat [deg], lon [deg] (47.1234567°, not 471234567°)
- * @param global_position_next next lat [deg], lon [deg] (8.1234567°, not 81234567°)
+ * @param global_position_now current lat [deg], lon [deg]
+ * @param global_position_next next lat [deg], lon [deg]
  * @return the vector [m^2] in local frame to the next global position (NE)
+ *
+ * @ingroup geodesic
 */
 Eigen::Vector2f vectorToGlobalPosition(
   const Eigen::Vector2d & global_position_now,
   const Eigen::Vector2d & global_position_next);
 
 /**
- * Compute the vector to the next global position in meters.
+ * @brief Compute the vector to the next global position in meters.
  *
- * @param global_position_now current lat [deg], lon [deg], alt AMSL [m] (47.1234567°, not 471234567°)
- * @param global_position_next next lat [deg], lon [deg], alt AMSL [m] (8.1234567°, not 81234567°)
+ * @param global_position_now current lat [deg], lon [deg], alt AMSL [m]
+ * @param global_position_next next lat [deg], lon [deg], alt AMSL [m]
  * @return the vector [m^3] in local frame to the next global position (NED)
+ *
+ * @ingroup geodesic
 */
 static inline Eigen::Vector3f vectorToGlobalPosition(
   const Eigen::Vector3d & global_position_now,
@@ -178,12 +219,14 @@ static inline Eigen::Vector3f vectorToGlobalPosition(
 }
 
 /**
- * Compute the global position on the line vector defined by two positions (start -> end) at a certain distance
+ * @brief Compute the global position on the line vector defined by two positions (start -> end) at a certain distance
  * from global position 'start'.
  *
- * @param global_position_line_start line start lat [deg], lon [deg] (47.1234567°, not 471234567°)
- * @param global_position_line_end line end lat [deg], lon [deg] (47.1234567°, not 471234567°)
+ * @param global_position_line_start line start lat [deg], lon [deg]
+ * @param global_position_line_end line end lat [deg], lon [deg]
  * @param dist distance [m] of target global position from position 'start' towards position 'end' (can be negative)
+ *
+ * @ingroup geodesic
  */
 Eigen::Vector2d globalPositionFromLineAndDist(
   const Eigen::Vector2d & global_position_line_start,
@@ -191,26 +234,30 @@ Eigen::Vector2d globalPositionFromLineAndDist(
   float dist_from_start);
 
 /**
- * Compute the global position given another global position, distance and heading
+ * @brief Compute the global position given another global position, distance and heading
  * see http://www.movable-type.co.uk/scripts/latlong.html
  *
- * @param global_position_now current lat [deg], lon [deg] (47.1234567°, not 471234567°)
+ * @param global_position_now current lat [deg], lon [deg]
  * @param heading heading from the current position [rad] (clockwise)
  * @param distance distance from the current position [m]
  * @return the target global position
+ *
+ * @ingroup geodesic
  */
 Eigen::Vector2d globalPositionFromHeadingAndDist(
   const Eigen::Vector2d & global_position_now,
   float heading, float dist);
 
 /**
- * Compute the global position given another global position, distance and heading
+ * @brief Compute the global position given another global position, distance and heading
  * see http://www.movable-type.co.uk/scripts/latlong.html
  *
- * @param global_position_now current lat [deg], lon [deg] (47.1234567°, not 471234567°)
+ * @param global_position_now current lat [deg], lon [deg]
  * @param heading heading from the current position [rad] (clockwise)
  * @param distance distance from the current position [m]
  * @return the target global position
+ *
+ * @ingroup geodesic
  */
 static inline Eigen::Vector3d globalPositionFromHeadingAndDist(
   const Eigen::Vector3d & global_position_now,
@@ -225,22 +272,26 @@ static inline Eigen::Vector3d globalPositionFromHeadingAndDist(
 }
 
 /**
- * Compute the global position from adding a local frame vector to the current global position.
+ * @brief Compute the global position from adding a local frame vector to the current global position.
  *
- * @param global_position current lat [deg], lon [deg] (47.1234567°, not 471234567°)
+ * @param global_position current lat [deg], lon [deg]
  * @param vector_ne local vector to add [m^2] (NE)
  * @return the resulting global position from the addition
+ *
+ * @ingroup geodesic
 */
 Eigen::Vector2d addVectorToGlobalPosition(
   const Eigen::Vector2d & global_position,
   const Eigen::Vector2f & vector_ne);
 
 /**
- * Compute the global position from adding a local frame vector to the current global position.
+ * @brief Compute the global position from adding a local frame vector to the current global position.
  *
- * @param global_position current lat [deg], lon [deg], alt AMSL [m] (47.1234567°, not 471234567°)
+ * @param global_position current lat [deg], lon [deg], alt AMSL [m]
  * @param vector_ne local vector to add [m^3] (NED)
  * @return the resulting global position from the addition
+ *
+ * @ingroup geodesic
 */
 static inline Eigen::Vector3d addVectorToGlobalPosition(
   const Eigen::Vector3d & global_position,
@@ -254,4 +305,5 @@ static inline Eigen::Vector3d addVectorToGlobalPosition(
     global_position.z() + d_alt};
 }
 
+/** @}*/
 }  // namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/utils/geometry.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/geometry.hpp
@@ -4,7 +4,8 @@
  ****************************************************************************/
 
 /**
- * @file geometry.hpp
+ * @defgroup geometry Geometry
+ * @ingroup utils
  *
  * All rotations and axis systems follow the right-hand rule
  *
@@ -27,6 +28,9 @@
 
 namespace px4_ros2
 {
+/** \ingroup geometry
+ *  @{
+ */
 
 /**
  * @brief Converts radians to degrees
@@ -185,4 +189,5 @@ Type quaternionToYaw(const Eigen::Quaternion<Type> & q)
   return std::atan2(2.0 * (x * y + w * z), w * w + x * x - y * y - z * z);
 }
 
+/** @}*/
 }  // namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/utils/groups.dox
+++ b/px4_ros2_cpp/include/px4_ros2/utils/groups.dox
@@ -1,0 +1,3 @@
+/*!
+\defgroup utils Utils
+*/

--- a/px4_ros2_cpp/src/utils/map_projection_impl.hpp
+++ b/px4_ros2_cpp/src/utils/map_projection_impl.hpp
@@ -91,7 +91,7 @@ public:
    * Transform a point in the geographic coordinate system to the local
    * azimuthal equidistant plane using the projection
    *
-   * @param global_position lat [deg], lon [deg] (degrees: 8.1234567°, not 81234567°)
+   * @param global_position lat [deg], lon [deg]
    * @return the point in local coordinates as north, east [m]
    */
   Eigen::Vector2f globalToLocal(const Eigen::Vector2d & global_position) const;
@@ -100,7 +100,7 @@ public:
    * Transform a point in the geographic coordinate system to the local
    * azimuthal equidistant plane using the projection
    *
-   * @param global_position lat [deg], lon [deg], alt AMSL [m] (degrees: 8.1234567°, not 81234567°)
+   * @param global_position lat [deg], lon [deg], alt AMSL [m]
    * @return the point in local coordinates as north, east, down [m]
    */
   inline Eigen::Vector3f globalToLocal(const Eigen::Vector3d & global_position) const
@@ -117,7 +117,7 @@ public:
    * geographic coordinate system using the projection
    *
    * @param local_position north, east [m]
-   * @return the point in geographic coordinates as lat [deg], lon [deg] (degrees: 8.1234567°, not 81234567°)
+   * @return the point in geographic coordinates as lat [deg], lon [deg]
    */
   Eigen::Vector2d localToGlobal(const Eigen::Vector2f & local_position) const;
 
@@ -126,7 +126,7 @@ public:
    * geographic coordinate system using the projection
    *
    * @param local_position north, east, down [m]
-   * @return the point in geographic coordinates as lat [deg], lon [deg], alt AMSL [m] (degrees: 8.1234567°, not 81234567°)
+   * @return the point in geographic coordinates as lat [deg], lon [deg], alt AMSL [m]
    */
   inline Eigen::Vector3d localToGlobal(const Eigen::Vector3f & local_position) const
   {

--- a/px4_ros2_cpp/test/unit/modes.cpp
+++ b/px4_ros2_cpp/test/unit/modes.cpp
@@ -7,6 +7,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <px4_ros2/components/health_and_arming_checks.hpp>
 #include <px4_ros2/components/mode.hpp>
+#include <px4_ros2/components/node_with_mode.hpp>
 #include <px4_ros2/control/setpoint_types/experimental/rates.hpp>
 #include <px4_ros2/odometry/global_position.hpp>
 #include "fake_registration.hpp"
@@ -48,4 +49,13 @@ TEST(modes, modeRequirements)
 
   mode->modeRequirements().clearAll();
   EXPECT_FALSE(mode->modeRequirements().angular_velocity);
+}
+
+TEST(modes, nodeWithMode)
+{
+  auto node_with_mode = std::make_shared<px4_ros2::NodeWithMode<TestMode>>("test_node");
+  EXPECT_TRUE(node_with_mode->getMode().modeRequirements().angular_velocity);
+
+  node_with_mode->getMode().modeRequirements().clearAll();
+  EXPECT_FALSE(node_with_mode->getMode().modeRequirements().angular_velocity);
 }


### PR DESCRIPTION
### Changes
- Adds template classes `NodeWithMode` and `NodeWithModeExecutor` to factorize repeated code in examples.
  - `NodeWithMode<ModeT>` instantiates and registers a mode of type `ModeT`.
  - `NodeWithModeExecutor<ExecutorModeT, ModeT>` instantiates and registers a mode executor of type `ExecutorModeT`. Also instantiates a mode of type `ModeT`, whose ownership is passed to the executor.
- Add doxygen group and subgroups for `utils/` folder.
  - In Doxyfile, set `EXTRACT_STATIC = YES` because many utils functions are static qualified and weren't shown.

Example usage `NodeWithMode`:
```
class MyMode : public px4_ros2::ModeBase {...};
rclcpp::spin(std::make_shared<px4_ros2::NodeWithMode<MyMode>>("my_node"));
```

Example usage `NodeWithModeExecutor`: 
```
class MyMode : public px4_ros2::ModeBase {...};
class MyExecutor : public px4_ros2::ModeExecutor {...};
rclcpp::spin(std::make_shared<px4_ros2::NodeWithMode<MyExecutor, MyMode>>("my_node"));
```

### Discussion

Alternative name ideas for `NodeWithMode`?
- `ModeControlNode`
- `ModeHandlingNode` / `ModeHandlerNode`
- ...

**JIRA**: [APX4-3823](https://auterion.atlassian.net/browse/APX4-3823)

[APX4-3823]: https://auterion.atlassian.net/browse/APX4-3823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ