### PR TITLE
Add OdometryAttitude class

### DIFF
--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -42,6 +42,7 @@ set(HEADER_FILES
         include/px4_ros2/navigation/experimental/global_position_measurement_interface.hpp
         include/px4_ros2/navigation/experimental/local_position_measurement_interface.hpp
         include/px4_ros2/navigation/experimental/navigation_interface_base.hpp
+        include/px4_ros2/odometry/attitude.hpp
         include/px4_ros2/odometry/global_position.hpp
         include/px4_ros2/odometry/local_position.hpp
         include/px4_ros2/utils/frame_conversion.hpp
@@ -67,6 +68,7 @@ add_library(px4_ros2_cpp
         src/control/setpoint_types/experimental/trajectory.cpp
         src/navigation/experimental/global_position_measurement_interface.cpp
         src/navigation/experimental/local_position_measurement_interface.cpp
+        src/odometry/attitude.cpp
         src/odometry/global_position.cpp
         src/odometry/local_position.cpp
         src/utils/geodesic.cpp

--- a/px4_ros2_cpp/include/px4_ros2/components/message_compatibility_check.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/message_compatibility_check.hpp
@@ -30,6 +30,7 @@ using namespace std::chrono_literals; // NOLINT
   {"/fmu/out/manual_control_setpoint"}, \
   {"/fmu/out/mode_completed"}, \
   {"/fmu/out/register_ext_component_reply"}, \
+  {"/fmu/out/vehicle_attitude"}, \
   {"/fmu/out/vehicle_command_ack"}, \
   {"/fmu/out/vehicle_global_position"}, \
   {"/fmu/out/vehicle_local_position"}, \

--- a/px4_ros2_cpp/include/px4_ros2/odometry/attitude.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/attitude.hpp
@@ -1,0 +1,71 @@
+/****************************************************************************
+ * Copyright (c) 2024 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#pragma once
+
+#include <Eigen/Eigen>
+#include <px4_msgs/msg/vehicle_attitude.hpp>
+#include <px4_ros2/common/context.hpp>
+#include <px4_ros2/odometry/subscription.hpp>
+#include <px4_ros2/utils/geometry.hpp>
+
+namespace px4_ros2
+{
+/** \ingroup odometry
+ *  @{
+ */
+
+/**
+ * Provides access to the vehicle's attitude estimate
+ */
+class OdometryAttitude : public Subscription<px4_msgs::msg::VehicleAttitude>
+{
+public:
+  explicit OdometryAttitude(Context & context);
+
+  /**
+   * @brief Get the vehicle's attitude.
+   *
+   * @return the attitude quaternion
+   */
+  Eigen::Quaternionf attitude() const
+  {
+    const px4_msgs::msg::VehicleAttitude & att = last();
+    return Eigen::Quaternionf{att.q[0], att.q[1], att.q[2], att.q[3]};
+  }
+
+  /**
+   * @brief Get the vehicle's roll in extrinsic RPY order.
+   *
+   * @return the attitude roll in radians within [-pi, pi]
+   */
+  float roll() const
+  {
+    return quaternionToRoll(attitude());
+  }
+
+  /**
+   * @brief Get the vehicle's pitch in extrinsic RPY order.
+   *
+   * @return the attitude pitch in radians within [-pi, pi]
+   */
+  float pitch() const
+  {
+    return quaternionToPitch(attitude());
+  }
+
+  /**
+   * @brief Get the vehicle's yaw in extrinsic RPY order.
+   *
+   * @return the attitude yaw in radians within [-pi, pi]
+   */
+  float yaw() const
+  {
+    return quaternionToYaw(attitude());
+  }
+};
+
+/** @}*/
+} /* namespace px4_ros2 */

--- a/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
@@ -60,6 +60,17 @@ public:
     const px4_msgs::msg::VehicleLocalPosition & pos = last();
     return {pos.ax, pos.ay, pos.az};
   }
+
+  /**
+   * @brief Get the vehicle's heading relative to NED earth-fixed frame.
+   *
+   * @return The vehicle's yaw in radians within [-pi, pi] using extrinsic RPY order
+  */
+  float heading() const
+  {
+    const px4_msgs::msg::VehicleLocalPosition & pos = last();
+    return pos.heading;
+  }
 };
 
 /** @}*/

--- a/px4_ros2_cpp/src/odometry/attitude.cpp
+++ b/px4_ros2_cpp/src/odometry/attitude.cpp
@@ -1,0 +1,19 @@
+/****************************************************************************
+ * Copyright (c) 2023 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#include <px4_ros2/odometry/attitude.hpp>
+
+namespace px4_ros2
+{
+
+OdometryAttitude::OdometryAttitude(Context & context)
+: Subscription<px4_msgs::msg::VehicleAttitude>(context, "/fmu/out/vehicle_attitude")
+{
+  RequirementFlags requirements{};
+  requirements.attitude = true;
+  context.setRequirement(requirements);
+}
+
+} // namespace px4_ros2


### PR DESCRIPTION
### Changes
- Add `OdometryAttitude` class.
- Add `heading()` getter to `OdometryLocalPosition` class.
- Use these interfaces in examples.

### Note
`OdometryAttitude::yaw()` and `OdometryLocalPosition::heading()` return the same value (up to PX4 timing), but I think it still makes sense to add a `OdometryLocalPosition::heading()` method for cases where the local position is already subscribed to e.g. in our local goto example.

**JIRA**: [APX4-3816](https://auterion.atlassian.net/browse/APX4-3816)

[APX4-3816]: https://auterion.atlassian.net/browse/APX4-3816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ