### PR TITLE
doxygen: add high level docs for classes

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/common/requirement_flags.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/common/requirement_flags.hpp
@@ -11,7 +11,7 @@ namespace px4_ros2
 {
 
 /**
- * Requirement flags used by modes
+ * @brief Requirement flags used by modes
  */
 struct RequirementFlags
 {

--- a/px4_ros2_cpp/include/px4_ros2/components/manual_control_input.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/manual_control_input.hpp
@@ -17,6 +17,9 @@ namespace px4_ros2
  *  @{
  */
 
+/**
+ * @brief Provides access to manually input control setpoints
+*/
 class ManualControlInput
 {
 public:

--- a/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
@@ -63,7 +63,7 @@ constexpr inline const char * resultToString(Result result) noexcept
 }
 
 /**
- * Base class for a mode
+ * @brief Base class for a mode
  * \ingroup components
  */
 class ModeBase : public Context

--- a/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
@@ -25,7 +25,7 @@ namespace px4_ros2
  */
 
 /**
- * Base class for a mode executor
+ * @brief Base class for a mode executor
  */
 class ModeExecutorBase
 {

--- a/px4_ros2_cpp/include/px4_ros2/control/peripheral_actuators.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/peripheral_actuators.hpp
@@ -17,7 +17,9 @@ namespace px4_ros2
  */
 
 /**
- * Control one or more extra actuators. It maps to the 'Peripheral Actuator Set' output functions on the PX4 side.
+ * @brief Provides control of one or more extra actuators.
+ *
+ * It maps to the 'Peripheral Actuator Set' output functions on the PX4 side.
  * This can be used by a mode independent from the setpoints.
  */
 class PeripheralActuatorControls

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/direct_actuators.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/direct_actuators.hpp
@@ -18,7 +18,7 @@ namespace px4_ros2
  */
 
 /**
- * Setpoint type for direct actuator control (servos and/or motors)
+ * @brief Setpoint type for direct actuator control (servos and/or motors)
  */
 class DirectActuatorsSetpointType : public SetpointBase
 {

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/attitude.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/attitude.hpp
@@ -16,6 +16,9 @@ namespace px4_ros2
  *  @{
  */
 
+/**
+ * @brief Setpoint type for direct attitude control
+*/
 class AttitudeSetpointType : public SetpointBase
 {
 public:

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/rates.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/rates.hpp
@@ -16,6 +16,9 @@ namespace px4_ros2
  *  @{
  */
 
+/**
+ * @brief Setpoint type for direct rate control
+*/
 class RatesSetpointType : public SetpointBase
 {
 public:

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/trajectory.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/trajectory.hpp
@@ -16,6 +16,11 @@ namespace px4_ros2
  *  @{
  */
 
+/**
+ * @brief Setpoint type for trajectory control
+ *
+ * Control entries must not be contradicting.
+*/
 class TrajectorySetpointType : public SetpointBase
 {
 public:

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/goto.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/goto.hpp
@@ -18,6 +18,9 @@ namespace px4_ros2
  *  @{
  */
 
+/**
+ * @brief Setpoint type for smooth position and heading control
+*/
 class GotoSetpointType : public SetpointBase
 {
 public:
@@ -54,6 +57,9 @@ private:
     _goto_setpoint_pub;
 };
 
+/**
+ * @brief Setpoint type for smooth global position and heading control
+*/
 class GotoGlobalSetpointType
 {
 public:

--- a/px4_ros2_cpp/include/px4_ros2/navigation/experimental/navigation_interface_base.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/navigation/experimental/navigation_interface_base.hpp
@@ -9,6 +9,10 @@
 
 namespace px4_ros2
 {
+
+/**
+ * @brief Thrown to report invalid arguments to measurement interface
+*/
 class NavigationInterfaceInvalidArgument : public std::invalid_argument
 {
 public:
@@ -16,6 +20,9 @@ public:
   : std::invalid_argument("PX4 ROS2 navigation interface: invalid argument: " + message) {}
 };
 
+/**
+ * @brief Base class for position measurement interface
+*/
 class PositionMeasurementInterfaceBase : public Context
 {
 public:

--- a/px4_ros2_cpp/include/px4_ros2/odometry/attitude.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/attitude.hpp
@@ -18,7 +18,7 @@ namespace px4_ros2
  */
 
 /**
- * Provides access to the vehicle's attitude estimate
+ * @brief Provides access to the vehicle's attitude estimate
  */
 class OdometryAttitude : public Subscription<px4_msgs::msg::VehicleAttitude>
 {

--- a/px4_ros2_cpp/include/px4_ros2/odometry/global_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/global_position.hpp
@@ -17,7 +17,7 @@ namespace px4_ros2
  */
 
 /**
- * Provides access to the vehicle's global position estimate
+ * @brief Provides access to the vehicle's global position estimate
  */
 class OdometryGlobalPosition : public Subscription<px4_msgs::msg::VehicleGlobalPosition>
 {

--- a/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
@@ -17,7 +17,7 @@ namespace px4_ros2
  */
 
 /**
- * Provides access to the vehicle's local position estimate
+ * @brief Provides access to the vehicle's local position estimate
  */
 class OdometryLocalPosition : public Subscription<px4_msgs::msg::VehicleLocalPosition>
 {

--- a/px4_ros2_cpp/include/px4_ros2/odometry/subscription.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/subscription.hpp
@@ -16,7 +16,7 @@ namespace px4_ros2
  */
 
 /**
- * Provides a subscription to arbitrary ROS topics.
+ * @brief Provides a subscription to arbitrary ROS topics.
  */
 template<typename RosMessageType>
 class Subscription


### PR DESCRIPTION
As mentioned [here](https://github.com/PX4/PX4-user_guide/pull/3076#pullrequestreview-1904929489), some doxygen annotations are missing from the "Class view" tab.

This adds the existing docs to the high level overview, and some extra descriptions.

Before:
![308354984-bbbd97d4-589e-406a-99bf-1356d7fb684f](https://github.com/Auterion/px4-ros2-interface-lib/assets/44861207/d4e58f85-4251-4b3a-86d2-8e57b57e614c)
After:
![image](https://github.com/Auterion/px4-ros2-interface-lib/assets/44861207/c80b94b9-881c-44d1-b6e8-acd31f2d9508)
