### PR TITLE
control: reduce default control update frequency

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/direct_actuators.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/direct_actuators.hpp
@@ -31,7 +31,7 @@ public:
   ~DirectActuatorsSetpointType() override = default;
 
   Configuration getConfiguration() override;
-  float desiredUpdateRateHz() override {return 100.f;}
+  float desiredUpdateRateHz() override {return 200.f;}
 
   /**
    * Send servos setpoint

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/direct_actuators.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/direct_actuators.hpp
@@ -31,7 +31,7 @@ public:
   ~DirectActuatorsSetpointType() override = default;
 
   Configuration getConfiguration() override;
-  float desiredUpdateRateHz() override {return 500.f;}
+  float desiredUpdateRateHz() override {return 100.f;}
 
   /**
    * Send servos setpoint

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/attitude.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/attitude.hpp
@@ -27,7 +27,7 @@ public:
   ~AttitudeSetpointType() override = default;
 
   Configuration getConfiguration() override;
-  float desiredUpdateRateHz() override {return 200.f;}
+  float desiredUpdateRateHz() override {return 100.f;}
 
   void update(
     const Eigen::Quaternionf & attitude_setpoint,

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/rates.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/rates.hpp
@@ -27,7 +27,7 @@ public:
   ~RatesSetpointType() override = default;
 
   Configuration getConfiguration() override;
-  float desiredUpdateRateHz() override {return 100.f;}
+  float desiredUpdateRateHz() override {return 200.f;}
 
   void update(
     const Eigen::Vector3f & rate_setpoints_ned_rad,

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/rates.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/rates.hpp
@@ -27,7 +27,7 @@ public:
   ~RatesSetpointType() override = default;
 
   Configuration getConfiguration() override;
-  float desiredUpdateRateHz() override {return 500.f;}
+  float desiredUpdateRateHz() override {return 100.f;}
 
   void update(
     const Eigen::Vector3f & rate_setpoints_ned_rad,

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -229,6 +229,7 @@ bool ModeBase::onRegistered()
 
   activateSetpointType(*_setpoint_types[0]);
   if (_setpoint_update_rate_hz < FLT_EPSILON) {
+    // Do not use default setpoint rate if rate was already set by user
     setSetpointUpdateRateFromSetpointTypes();
   }
 

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -228,7 +228,9 @@ bool ModeBase::onRegistered()
   // TODO: check setpoint types compatibility with current vehicle type
 
   activateSetpointType(*_setpoint_types[0]);
-  setSetpointUpdateRateFromSetpointTypes();
+  if (_setpoint_update_rate_hz < FLT_EPSILON) {
+    setSetpointUpdateRateFromSetpointTypes();
+  }
 
   return true;
 }


### PR DESCRIPTION
### Changes
- Reduce default control update frequency to 100Hz
- Do not trigger `setSetpointUpdateRateFromSetpointTypes()` after registration if the mode has already set a desired setpoint update rate (e.g. already called `setSetpointUpdateRate()` in the mode constructor)

### Testing
- Tested in SITL that the expected control frequency is set when specifying / not specifying an update rate in the mode's constructor / onActivate