### PR TITLE
fix usage of ROS namespaces

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Compatibility is only guaranteed if using latest `main` on the PX4 and px4_ros2/
 The library checks for message compatibility on startup when registering a mode.
 `ALL_PX4_ROS2_MESSAGES` defines the set of checked messages. If you use other messages, you can check them using:
 ```cpp
-if (!px4_ros2::messageCompatibilityCheck(node, {{"/fmu/in/vehicle_rates_setpoint"}})) {
+if (!px4_ros2::messageCompatibilityCheck(node, {{"fmu/in/vehicle_rates_setpoint"}})) {
   throw std::runtime_error("Messages incompatible");
 }
 ```

--- a/examples/cpp/modes/rtl_replacement/include/mode.hpp
+++ b/examples/cpp/modes/rtl_replacement/include/mode.hpp
@@ -25,7 +25,7 @@ public:
   : ModeBase(node, Settings{kName, true, ModeBase::kModeIDRtl})
   {
     _vehicle_land_detected_sub = node.create_subscription<px4_msgs::msg::VehicleLandDetected>(
-      "/fmu/out/vehicle_land_detected", rclcpp::QoS(1).best_effort(),
+      "fmu/out/vehicle_land_detected", rclcpp::QoS(1).best_effort(),
       [this](px4_msgs::msg::VehicleLandDetected::UniquePtr msg) {
         _landed = msg->landed;
       });

--- a/px4_ros2_cpp/include/px4_ros2/components/message_compatibility_check.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/message_compatibility_check.hpp
@@ -10,31 +10,31 @@ using namespace std::chrono_literals; // NOLINT
 
 // Set of all messages used by the library (<topic_name>[, <topic_type>])
 #define ALL_PX4_ROS2_MESSAGES \
-  {"/fmu/in/actuator_motors"}, \
-  {"/fmu/in/actuator_servos"}, \
-  {"/fmu/in/arming_check_reply"}, \
-  {"/fmu/in/aux_global_position", "VehicleGlobalPosition"}, \
-  {"/fmu/in/config_control_setpoints", "VehicleControlMode"}, \
-  {"/fmu/in/config_overrides_request", "ConfigOverrides"}, \
-  {"/fmu/in/goto_setpoint"}, \
-  {"/fmu/in/mode_completed"}, \
-  {"/fmu/in/register_ext_component_request"}, \
-  {"/fmu/in/trajectory_setpoint"}, \
-  {"/fmu/in/unregister_ext_component"}, \
-  {"/fmu/in/vehicle_attitude_setpoint"}, \
-  {"/fmu/in/vehicle_command"}, \
-  {"/fmu/in/vehicle_command_mode_executor", "VehicleCommand"}, \
-  {"/fmu/in/vehicle_rates_setpoint"}, \
-  {"/fmu/in/vehicle_visual_odometry", "VehicleOdometry"}, \
-  {"/fmu/out/arming_check_request"}, \
-  {"/fmu/out/manual_control_setpoint"}, \
-  {"/fmu/out/mode_completed"}, \
-  {"/fmu/out/register_ext_component_reply"}, \
-  {"/fmu/out/vehicle_attitude"}, \
-  {"/fmu/out/vehicle_command_ack"}, \
-  {"/fmu/out/vehicle_global_position"}, \
-  {"/fmu/out/vehicle_local_position"}, \
-  {"/fmu/out/vehicle_status"}
+  {"fmu/in/actuator_motors"}, \
+  {"fmu/in/actuator_servos"}, \
+  {"fmu/in/arming_check_reply"}, \
+  {"fmu/in/aux_global_position", "VehicleGlobalPosition"}, \
+  {"fmu/in/config_control_setpoints", "VehicleControlMode"}, \
+  {"fmu/in/config_overrides_request", "ConfigOverrides"}, \
+  {"fmu/in/goto_setpoint"}, \
+  {"fmu/in/mode_completed"}, \
+  {"fmu/in/register_ext_component_request"}, \
+  {"fmu/in/trajectory_setpoint"}, \
+  {"fmu/in/unregister_ext_component"}, \
+  {"fmu/in/vehicle_attitude_setpoint"}, \
+  {"fmu/in/vehicle_command"}, \
+  {"fmu/in/vehicle_command_mode_executor", "VehicleCommand"}, \
+  {"fmu/in/vehicle_rates_setpoint"}, \
+  {"fmu/in/vehicle_visual_odometry", "VehicleOdometry"}, \
+  {"fmu/out/arming_check_request"}, \
+  {"fmu/out/manual_control_setpoint"}, \
+  {"fmu/out/mode_completed"}, \
+  {"fmu/out/register_ext_component_reply"}, \
+  {"fmu/out/vehicle_attitude"}, \
+  {"fmu/out/vehicle_command_ack"}, \
+  {"fmu/out/vehicle_global_position"}, \
+  {"fmu/out/vehicle_local_position"}, \
+  {"fmu/out/vehicle_status"}
 
 
 namespace px4_ros2
@@ -45,7 +45,7 @@ namespace px4_ros2
 
 struct MessageCompatibilityTopic
 {
-  std::string topic_name;       ///< e.g. "/fmu/out/vehicle_status"
+  std::string topic_name;       ///< e.g. "fmu/out/vehicle_status"
   std::string topic_type{""};       ///< e.g. VehicleStatus. If empty, it's inferred from the topic_name // NOLINT
 };
 

--- a/px4_ros2_cpp/src/components/health_and_arming_checks.cpp
+++ b/px4_ros2_cpp/src/components/health_and_arming_checks.cpp
@@ -21,10 +21,10 @@ HealthAndArmingChecks::HealthAndArmingChecks(
   _check_callback(std::move(check_callback))
 {
   _arming_check_reply_pub = _node.create_publisher<px4_msgs::msg::ArmingCheckReply>(
-    topic_namespace_prefix + "/fmu/in/arming_check_reply", 1);
+    topic_namespace_prefix + "fmu/in/arming_check_reply", 1);
 
   _arming_check_request_sub = _node.create_subscription<px4_msgs::msg::ArmingCheckRequest>(
-    topic_namespace_prefix + "/fmu/out/arming_check_request",
+    topic_namespace_prefix + "fmu/out/arming_check_request",
     rclcpp::QoS(1).best_effort(),
     [this](px4_msgs::msg::ArmingCheckRequest::UniquePtr msg) {
 

--- a/px4_ros2_cpp/src/components/manual_control_input.cpp
+++ b/px4_ros2_cpp/src/components/manual_control_input.cpp
@@ -16,7 +16,7 @@ ManualControlInput::ManualControlInput(Context & context, bool is_optional)
 
   _manual_control_setpoint_sub =
     context.node().create_subscription<px4_msgs::msg::ManualControlSetpoint>(
-    context.topicNamespacePrefix() + "/fmu/out/manual_control_setpoint", rclcpp::QoS(
+    context.topicNamespacePrefix() + "fmu/out/manual_control_setpoint", rclcpp::QoS(
       1).best_effort(),
     [this](px4_msgs::msg::ManualControlSetpoint::UniquePtr msg) {
       _manual_control_setpoint = *msg;

--- a/px4_ros2_cpp/src/components/message_compatibility_check.cpp
+++ b/px4_ros2_cpp/src/components/message_compatibility_check.cpp
@@ -229,13 +229,13 @@ bool messageCompatibilityCheck(
     message_format_response_sub
     =
     node.create_subscription<px4_msgs::msg::MessageFormatResponse>(
-      topic_namespace_prefix + "/fmu/out/message_format_response", rclcpp::QoS(1).best_effort(),
+      topic_namespace_prefix + "fmu/out/message_format_response", rclcpp::QoS(1).best_effort(),
       [](px4_msgs::msg::MessageFormatResponse::UniquePtr msg) {});
 
   const rclcpp::Publisher<px4_msgs::msg::MessageFormatRequest>::SharedPtr message_format_request_pub
     =
     node.create_publisher<px4_msgs::msg::MessageFormatRequest>(
-      topic_namespace_prefix + "/fmu/in/message_format_request", 1);
+      topic_namespace_prefix + "fmu/in/message_format_request", 1);
 
   const std::string msgs_dir = ament_index_cpp::get_package_share_directory("px4_msgs");
   if (msgs_dir.empty()) {

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -27,16 +27,16 @@ ModeBase::ModeBase(
     topic_namespace_prefix), _config_overrides(node, topic_namespace_prefix)
 {
   _vehicle_status_sub = node.create_subscription<px4_msgs::msg::VehicleStatus>(
-    topic_namespace_prefix + "/fmu/out/vehicle_status", rclcpp::QoS(1).best_effort(),
+    topic_namespace_prefix + "fmu/out/vehicle_status", rclcpp::QoS(1).best_effort(),
     [this](px4_msgs::msg::VehicleStatus::UniquePtr msg) {
       if (_registration->registered()) {
         vehicleStatusUpdated(msg);
       }
     });
   _mode_completed_pub = node.create_publisher<px4_msgs::msg::ModeCompleted>(
-    topic_namespace_prefix + "/fmu/in/mode_completed", 1);
+    topic_namespace_prefix + "fmu/in/mode_completed", 1);
   _config_control_setpoints_pub = node.create_publisher<px4_msgs::msg::VehicleControlMode>(
-    topic_namespace_prefix + "/fmu/in/config_control_setpoints", 1);
+    topic_namespace_prefix + "fmu/in/config_control_setpoints", 1);
 }
 
 ModeBase::ModeID ModeBase::id() const

--- a/px4_ros2_cpp/src/components/mode_executor.cpp
+++ b/px4_ros2_cpp/src/components/mode_executor.cpp
@@ -25,7 +25,7 @@ ModeExecutorBase::ModeExecutorBase(
   _config_overrides(node, topic_namespace_prefix)
 {
   _vehicle_status_sub = _node.create_subscription<px4_msgs::msg::VehicleStatus>(
-    topic_namespace_prefix + "/fmu/out/vehicle_status", rclcpp::QoS(1).best_effort(),
+    topic_namespace_prefix + "fmu/out/vehicle_status", rclcpp::QoS(1).best_effort(),
     [this](px4_msgs::msg::VehicleStatus::UniquePtr msg) {
       if (_registration->registered()) {
         vehicleStatusUpdated(msg);
@@ -33,10 +33,10 @@ ModeExecutorBase::ModeExecutorBase(
     });
 
   _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
-    topic_namespace_prefix + "/fmu/in/vehicle_command_mode_executor", 1);
+    topic_namespace_prefix + "fmu/in/vehicle_command_mode_executor", 1);
 
   _vehicle_command_ack_sub = _node.create_subscription<px4_msgs::msg::VehicleCommandAck>(
-    topic_namespace_prefix + "/fmu/out/vehicle_command_ack", rclcpp::QoS(1).best_effort(),
+    topic_namespace_prefix + "fmu/out/vehicle_command_ack", rclcpp::QoS(1).best_effort(),
     [](px4_msgs::msg::VehicleCommandAck::UniquePtr msg) {});
 }
 
@@ -397,7 +397,7 @@ ModeExecutorBase::ScheduledMode::ScheduledMode(
   const std::string & topic_namespace_prefix)
 {
   _mode_completed_sub = node.create_subscription<px4_msgs::msg::ModeCompleted>(
-    topic_namespace_prefix + "/fmu/out/mode_completed", rclcpp::QoS(1).best_effort(),
+    topic_namespace_prefix + "fmu/out/mode_completed", rclcpp::QoS(1).best_effort(),
     [this, &node](px4_msgs::msg::ModeCompleted::UniquePtr msg) {
       if (active() && msg->nav_state == static_cast<uint8_t>(_mode_id)) {
         RCLCPP_DEBUG(

--- a/px4_ros2_cpp/src/components/overrides.cpp
+++ b/px4_ros2_cpp/src/components/overrides.cpp
@@ -14,7 +14,7 @@ ConfigOverrides::ConfigOverrides(rclcpp::Node & node, const std::string & topic_
 : _node(node)
 {
   _config_overrides_pub = _node.create_publisher<px4_msgs::msg::ConfigOverrides>(
-    topic_namespace_prefix + "/fmu/in/config_overrides_request", 1);
+    topic_namespace_prefix + "fmu/in/config_overrides_request", 1);
 }
 
 void ConfigOverrides::controlAutoDisarm(bool enabled)

--- a/px4_ros2_cpp/src/components/registration.cpp
+++ b/px4_ros2_cpp/src/components/registration.cpp
@@ -18,17 +18,17 @@ Registration::Registration(rclcpp::Node & node, const std::string & topic_namesp
 {
   _register_ext_component_reply_sub =
     node.create_subscription<px4_msgs::msg::RegisterExtComponentReply>(
-    topic_namespace_prefix + "/fmu/out/register_ext_component_reply",
+    topic_namespace_prefix + "fmu/out/register_ext_component_reply",
     rclcpp::QoS(1).best_effort(),
     [](px4_msgs::msg::RegisterExtComponentReply::UniquePtr msg) {
     });
 
   _register_ext_component_request_pub =
     node.create_publisher<px4_msgs::msg::RegisterExtComponentRequest>(
-    topic_namespace_prefix + "/fmu/in/register_ext_component_request", 1);
+    topic_namespace_prefix + "fmu/in/register_ext_component_request", 1);
 
   _unregister_ext_component_pub = node.create_publisher<px4_msgs::msg::UnregisterExtComponent>(
-    topic_namespace_prefix + "/fmu/in/unregister_ext_component", 1);
+    topic_namespace_prefix + "fmu/in/unregister_ext_component", 1);
 
   _unregister_ext_component.mode_id = px4_ros2::ModeBase::kModeIDInvalid;
 }

--- a/px4_ros2_cpp/src/components/wait_for_fmu.cpp
+++ b/px4_ros2_cpp/src/components/wait_for_fmu.cpp
@@ -16,7 +16,7 @@ bool waitForFMU(
   RCLCPP_INFO(node.get_logger(), "Waiting for FMU...");
   const rclcpp::Subscription<px4_msgs::msg::VehicleStatus>::SharedPtr vehicle_status_sub =
     node.create_subscription<px4_msgs::msg::VehicleStatus>(
-    topic_namespace_prefix + "/fmu/out/vehicle_status", rclcpp::QoS(1).best_effort(),
+    topic_namespace_prefix + "fmu/out/vehicle_status", rclcpp::QoS(1).best_effort(),
     [](px4_msgs::msg::VehicleStatus::UniquePtr msg) {});
 
   rclcpp::WaitSet wait_set;

--- a/px4_ros2_cpp/src/control/peripheral_actuators.cpp
+++ b/px4_ros2_cpp/src/control/peripheral_actuators.cpp
@@ -14,7 +14,7 @@ PeripheralActuatorControls::PeripheralActuatorControls(Context & context)
 : _node(context.node())
 {
   _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
-    context.topicNamespacePrefix() + "/fmu/in/vehicle_command", 1);
+    context.topicNamespacePrefix() + "fmu/in/vehicle_command", 1);
   _last_update = _node.get_clock()->now();
 }
 

--- a/px4_ros2_cpp/src/control/setpoint_types/direct_actuators.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/direct_actuators.cpp
@@ -13,9 +13,9 @@ DirectActuatorsSetpointType::DirectActuatorsSetpointType(Context & context)
 : SetpointBase(context), _node(context.node())
 {
   _actuator_motors_pub = context.node().create_publisher<px4_msgs::msg::ActuatorMotors>(
-    context.topicNamespacePrefix() + "/fmu/in/actuator_motors", 1);
+    context.topicNamespacePrefix() + "fmu/in/actuator_motors", 1);
   _actuator_servos_pub = context.node().create_publisher<px4_msgs::msg::ActuatorServos>(
-    context.topicNamespacePrefix() + "/fmu/in/actuator_servos", 1);
+    context.topicNamespacePrefix() + "fmu/in/actuator_servos", 1);
 }
 
 void DirectActuatorsSetpointType::updateMotors(

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/attitude.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/attitude.cpp
@@ -15,7 +15,7 @@ AttitudeSetpointType::AttitudeSetpointType(Context & context)
 {
   _vehicle_attitude_setpoint_pub =
     context.node().create_publisher<px4_msgs::msg::VehicleAttitudeSetpoint>(
-    context.topicNamespacePrefix() + "/fmu/in/vehicle_attitude_setpoint", 1);
+    context.topicNamespacePrefix() + "fmu/in/vehicle_attitude_setpoint", 1);
 }
 
 void AttitudeSetpointType::update(

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/rates.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/rates.cpp
@@ -14,7 +14,7 @@ RatesSetpointType::RatesSetpointType(Context & context)
 {
   _vehicle_rates_setpoint_pub =
     context.node().create_publisher<px4_msgs::msg::VehicleRatesSetpoint>(
-    context.topicNamespacePrefix() + "/fmu/in/vehicle_rates_setpoint", 1);
+    context.topicNamespacePrefix() + "fmu/in/vehicle_rates_setpoint", 1);
 }
 
 void RatesSetpointType::update(

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/trajectory.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/trajectory.cpp
@@ -13,7 +13,7 @@ TrajectorySetpointType::TrajectorySetpointType(Context & context)
 : SetpointBase(context), _node(context.node())
 {
   _trajectory_setpoint_pub = context.node().create_publisher<px4_msgs::msg::TrajectorySetpoint>(
-    context.topicNamespacePrefix() + "/fmu/in/trajectory_setpoint", 1);
+    context.topicNamespacePrefix() + "fmu/in/trajectory_setpoint", 1);
 }
 
 void TrajectorySetpointType::update(

--- a/px4_ros2_cpp/src/control/setpoint_types/goto.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/goto.cpp
@@ -14,7 +14,7 @@ GotoSetpointType::GotoSetpointType(Context & context)
 {
   _goto_setpoint_pub =
     context.node().create_publisher<px4_msgs::msg::GotoSetpoint>(
-    context.topicNamespacePrefix() + "/fmu/in/goto_setpoint", 1);
+    context.topicNamespacePrefix() + "fmu/in/goto_setpoint", 1);
 }
 
 void GotoSetpointType::update(
@@ -84,7 +84,7 @@ void GotoGlobalSetpointType::update(
   if (!_map_projection->isInitialized()) {
     RCLCPP_ERROR_ONCE(
       _node.get_logger(),
-      "Goto global setpoint update failed: map projection is uninitialized. Is /fmu/out/vehicle_local_position published?");
+      "Goto global setpoint update failed: map projection is uninitialized. Is fmu/out/vehicle_local_position published?");
     return;
   }
 

--- a/px4_ros2_cpp/src/navigation/experimental/global_position_measurement_interface.cpp
+++ b/px4_ros2_cpp/src/navigation/experimental/global_position_measurement_interface.cpp
@@ -16,7 +16,7 @@ GlobalPositionMeasurementInterface::GlobalPositionMeasurementInterface(rclcpp::N
 {
   _aux_global_position_pub =
     node.create_publisher<VehicleGlobalPosition>(
-    topicNamespacePrefix() + "/fmu/in/aux_global_position", 10);
+    topicNamespacePrefix() + "fmu/in/aux_global_position", 10);
 }
 
 void GlobalPositionMeasurementInterface::update(

--- a/px4_ros2_cpp/src/navigation/experimental/local_position_measurement_interface.cpp
+++ b/px4_ros2_cpp/src/navigation/experimental/local_position_measurement_interface.cpp
@@ -19,7 +19,7 @@ LocalPositionMeasurementInterface::LocalPositionMeasurementInterface(
   _velocity_frame(velocityFrameToMessageFrame(velocity_frame))
 {
   _aux_local_position_pub = node.create_publisher<AuxLocalPosition>(
-    topicNamespacePrefix() + "/fmu/in/vehicle_visual_odometry", 10);
+    topicNamespacePrefix() + "fmu/in/vehicle_visual_odometry", 10);
 }
 
 void LocalPositionMeasurementInterface::update(

--- a/px4_ros2_cpp/src/odometry/attitude.cpp
+++ b/px4_ros2_cpp/src/odometry/attitude.cpp
@@ -9,7 +9,7 @@ namespace px4_ros2
 {
 
 OdometryAttitude::OdometryAttitude(Context & context)
-: Subscription<px4_msgs::msg::VehicleAttitude>(context, "/fmu/out/vehicle_attitude")
+: Subscription<px4_msgs::msg::VehicleAttitude>(context, "fmu/out/vehicle_attitude")
 {
   RequirementFlags requirements{};
   requirements.attitude = true;

--- a/px4_ros2_cpp/src/odometry/global_position.cpp
+++ b/px4_ros2_cpp/src/odometry/global_position.cpp
@@ -9,7 +9,7 @@ namespace px4_ros2
 {
 
 OdometryGlobalPosition::OdometryGlobalPosition(Context & context)
-: Subscription<px4_msgs::msg::VehicleGlobalPosition>(context, "/fmu/out/vehicle_global_position")
+: Subscription<px4_msgs::msg::VehicleGlobalPosition>(context, "fmu/out/vehicle_global_position")
 {
   RequirementFlags requirements{};
   requirements.global_position = true;

--- a/px4_ros2_cpp/src/odometry/local_position.cpp
+++ b/px4_ros2_cpp/src/odometry/local_position.cpp
@@ -9,7 +9,7 @@ namespace px4_ros2
 {
 
 OdometryLocalPosition::OdometryLocalPosition(Context & context)
-: Subscription<px4_msgs::msg::VehicleLocalPosition>(context, "/fmu/out/vehicle_local_position")
+: Subscription<px4_msgs::msg::VehicleLocalPosition>(context, "fmu/out/vehicle_local_position")
 {
   RequirementFlags requirements{};
   requirements.local_position = true;

--- a/px4_ros2_cpp/src/utils/geodesic.cpp
+++ b/px4_ros2_cpp/src/utils/geodesic.cpp
@@ -15,7 +15,7 @@ MapProjection::MapProjection(Context & context)
 {
   _map_projection_math = std::make_unique<MapProjectionImpl>();
   _vehicle_local_position_sub = _node.create_subscription<px4_msgs::msg::VehicleLocalPosition>(
-    "/fmu/out/vehicle_local_position", rclcpp::QoS(1).best_effort(),
+    "fmu/out/vehicle_local_position", rclcpp::QoS(1).best_effort(),
     [this](px4_msgs::msg::VehicleLocalPosition::UniquePtr msg) {
       vehicleLocalPositionCallback(std::move(msg));
     });

--- a/px4_ros2_cpp/test/integration/global_navigation.cpp
+++ b/px4_ros2_cpp/test/integration/global_navigation.cpp
@@ -35,7 +35,7 @@ protected:
 
     // Subscribe to PX4 EKF estimator status flags
     _subscriber = _node->create_subscription<EstimatorStatusFlags>(
-      "/fmu/out/estimator_status_flags", rclcpp::QoS(10).best_effort(),
+      "fmu/out/estimator_status_flags", rclcpp::QoS(10).best_effort(),
       [this](EstimatorStatusFlags::UniquePtr msg) {
         _estimator_status_flags = std::move(msg);
       });
@@ -84,7 +84,7 @@ protected:
 
       if (elapsed_time >= kTimeoutDuration) {
         ASSERT_NE(_estimator_status_flags, nullptr) <<
-          "Missing feedback from PX4: no estimator status flags published over /fmu/out/estimator_status_flags.";
+          "Missing feedback from PX4: no estimator status flags published over fmu/out/estimator_status_flags.";
         EXPECT_TRUE(is_fused_getter(_estimator_status_flags)) <<
           "Position measurement update was not fused into the PX4 EKF.";
         break;

--- a/px4_ros2_cpp/test/integration/local_navigation.cpp
+++ b/px4_ros2_cpp/test/integration/local_navigation.cpp
@@ -40,7 +40,7 @@ protected:
 
     // Subscribe to PX4 EKF estimator status flags
     _subscriber = _node->create_subscription<EstimatorStatusFlags>(
-      "/fmu/out/estimator_status_flags", rclcpp::QoS(10).best_effort(),
+      "fmu/out/estimator_status_flags", rclcpp::QoS(10).best_effort(),
       [this](EstimatorStatusFlags::UniquePtr msg) {
         _estimator_status_flags = std::move(msg);
       });
@@ -91,7 +91,7 @@ protected:
 
       if (elapsed_time >= kTimeoutDuration) {
         ASSERT_NE(_estimator_status_flags, nullptr) <<
-          "Missing feedback from PX4: no estimator status flags published over /fmu/out/estimator_status_flags.";
+          "Missing feedback from PX4: no estimator status flags published over fmu/out/estimator_status_flags.";
         EXPECT_TRUE(is_fused_getter(_estimator_status_flags)) <<
           "Position measurement update was not fused into the PX4 EKF.";
         break;

--- a/px4_ros2_cpp/test/integration/util.cpp
+++ b/px4_ros2_cpp/test/integration/util.cpp
@@ -26,7 +26,7 @@ VehicleState::VehicleState(rclcpp::Node & node, const std::string & topic_namesp
 : _node(node)
 {
   _vehicle_status_sub = _node.create_subscription<px4_msgs::msg::VehicleStatus>(
-    topic_namespace_prefix + "/fmu/out/vehicle_status", rclcpp::QoS(1).best_effort(),
+    topic_namespace_prefix + "fmu/out/vehicle_status", rclcpp::QoS(1).best_effort(),
     [this](px4_msgs::msg::VehicleStatus::UniquePtr msg) {
       if (_on_vehicle_status_update) {
         _on_vehicle_status_update(msg);
@@ -43,7 +43,7 @@ VehicleState::VehicleState(rclcpp::Node & node, const std::string & topic_namesp
     });
 
   _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
-    topic_namespace_prefix + "/fmu/in/vehicle_command", 1);
+    topic_namespace_prefix + "fmu/in/vehicle_command", 1);
 
 }
 

--- a/scripts/check-used-topics.py
+++ b/scripts/check-used-topics.py
@@ -27,7 +27,7 @@ def extract_topics_from_file(filename: str, extract_start_after: str = None,
 
         ret = []
         for line in file:
-            m = re.search(r'"/fmu/(in|out)/([^"]+)', line)
+            m = re.search(r'"fmu/(in|out)/([^"]+)', line)
             if m:
                 ret.append(m.group(2))
 


### PR DESCRIPTION
Currently the library do not take into account the namespace if specified. The micro DDS client allows in PX4 to configure a custom namespace (multiple drones on the same network). To reflect this, it would be good to also allow this library to use custom namespaces. Removing "/" in front of topic definitions solve this. The topics will reflect the chosen namespace for the node.