### PR TITLE
fix registering issue when node is not immediately spinned

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/components/node_with_mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/node_with_mode.hpp
@@ -50,7 +50,10 @@ public:
     }
 
     _mode = std::make_unique<ModeT>(*this);
+  }
 
+  void doRegister()
+  {
     if (!_mode->doRegister()) {
       throw std::runtime_error("Registration failed");
     }
@@ -109,7 +112,10 @@ public:
 
     _mode = std::make_unique<ModeT>(*this);
     _mode_executor = std::make_unique<ModeExecutorT>(*this, *_mode);
+  }
 
+  void doRegister()
+  {
     if (!_mode_executor->doRegister()) {
       throw std::runtime_error("Registration failed");
     }
@@ -118,6 +124,11 @@ public:
   ModeT & getMode() const
   {
     return *_mode;
+  }
+
+  ModeExecutorT & getModeExecutor() const
+  {
+    return *_mode_executor;
   }
 
 private:


### PR DESCRIPTION
Hello,

Here is a suggestion for the classes in NodeWithMode. They immediately trigger the registering but if you don't spin the node fast enough (like I do since I need extra configuration after the creation of the instance)
- then you quickly get flagged unresponsive by the Autopilot 
- then disconnection happen because the Autopilot is not sending you check request anymore when flagged unresponsive (is it wanted? or a bug?)

In all cases, it could be good to either:
1) let the hand to the user to trigger the registration just before spinning the node 
2) have a more complex mechanism to check that the node is spinning before doing the registration.

The modification if put in this PR is for solution 1). However, this changes usage as the user must do the registration "manually" before spinning the node. 
So I am open to suggestions on this.

Also, I did a minor modification to access the Executor because you might need that if you want to access specific functions you implemented in the class inherited from ExecutorBase.

Damien
