### PR TITLE
Add global navigation reset method

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/navigation/experimental/global_position_measurement_interface.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/navigation/experimental/global_position_measurement_interface.hpp
@@ -67,8 +67,8 @@ public:
  *
  * Increments the reset counter for horizontal position (latitude and longitude) to signal the EKF
  * of a discontinuity in external position data (e.g., loss of tracking or reinitialization). Future measurement
- * updates will contain the incremented counter. This helps the EKF adjust and maintain consistent state estimation,
- * and accept new measurements after a gap or inconsistency in updates.
+ * updates will contain the incremented counter. This prevents the EKF from rejecting future measurement updates
+ * after an inconsistency in data.
  */
   inline void reset() {++_lat_lon_reset_counter;}
 

--- a/px4_ros2_cpp/include/px4_ros2/navigation/experimental/global_position_measurement_interface.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/navigation/experimental/global_position_measurement_interface.hpp
@@ -62,6 +62,16 @@ public:
    */
   void update(const GlobalPositionMeasurement & global_position_measurement) const;
 
+/**
+ * @brief Notify the FMU that the global position estimate has been reset.
+ *
+ * Increments the reset counter for horizontal position (latitude and longitude) to signal the EKF
+ * of a discontinuity in external position data (e.g., loss of tracking or reinitialization). Future measurement
+ * updates will contain the incremented counter. This helps the EKF adjust and maintain consistent state estimation,
+ * and accept new measurements after a gap or inconsistency in updates.
+ */
+  inline void reset() {++_lat_lon_reset_counter;}
+
 private:
   /**
    * @brief Check that at least one measurement value is defined.
@@ -85,6 +95,7 @@ private:
 
   rclcpp::Publisher<px4_msgs::msg::VehicleGlobalPosition>::SharedPtr _aux_global_position_pub;
 
+  uint8_t _lat_lon_reset_counter{0};  /** Counter for reset events on horizontal position coordinates */
   // uint8_t _altitude_frame;
 };
 

--- a/px4_ros2_cpp/src/navigation/experimental/global_position_measurement_interface.cpp
+++ b/px4_ros2_cpp/src/navigation/experimental/global_position_measurement_interface.cpp
@@ -41,6 +41,7 @@ void GlobalPositionMeasurementInterface::update(
 
   // Populate aux global position
   VehicleGlobalPosition aux_global_position;
+  aux_global_position.lat_lon_reset_counter = _lat_lon_reset_counter;
 
   aux_global_position.timestamp_sample =
     global_position_measurement.timestamp_sample.nanoseconds() *


### PR DESCRIPTION
### Changes

Add reset method to increment the position reset counter

Only incrementing the lat_lon reset counter since it seems to be the only counter processed in the AuxGlobalPosition module in PX4: https://github.com/Auterion/PX4_firmware_private/blob/eaa169d211a19ecbd37a454846eb117e40ec204d/src/modules/ekf2/EKF/aid_sources/aux_global_position/aux_global_position.cpp#L59

### Testing

Only unit-testing