### PR TITLE
mode: extends available replacements to loiter mode

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
@@ -85,7 +85,7 @@ public:
   static constexpr ModeID kModeIDPrecisionLand =
     px4_msgs::msg::VehicleStatus::NAVIGATION_STATE_AUTO_PRECLAND;
   static constexpr ModeID kModeIDLoiter =
-    px4_msgs::msg::VehicleStatus::NAVIGATION_STATE_AUTO_LOITER;  
+    px4_msgs::msg::VehicleStatus::NAVIGATION_STATE_AUTO_LOITER;
 
   struct Settings
   {

--- a/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
@@ -84,6 +84,8 @@ public:
     px4_msgs::msg::VehicleStatus::NAVIGATION_STATE_AUTO_RTL;
   static constexpr ModeID kModeIDPrecisionLand =
     px4_msgs::msg::VehicleStatus::NAVIGATION_STATE_AUTO_PRECLAND;
+  static constexpr ModeID kModeIDLoiter =
+    px4_msgs::msg::VehicleStatus::NAVIGATION_STATE_AUTO_LOITER;  
 
   struct Settings
   {


### PR DESCRIPTION
Enhanced mode replacement options to consider Loiter, nav-state 4.

Testing
- [ ] Bench (aimed for EOD 27.11.2024) 
- [ ] Flight-test (tbd)