### PR TITLE
Run linting CI on Ubuntu 22.04

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The `ubuntu-latest` GitHub Actions runner upgraded from Ubuntu 22.04 to 24.04 in December 2024.

`ament-lint` is not yet available on Ubuntu 24.04, so here we pin the runner to `ubuntu-22.04`.