### PR TITLE
apply version suffix to fmu topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PX4 ROS 2 Interface Library
 
 Library to interface with PX4 from a companion computer using ROS 2.
-It provides some tooling to used to write external modes that are dynamically registered with PX4 and behave the same way as internal ones.
+It provides some tooling used to write external modes that are dynamically registered with PX4 and behave the same way as internal ones.
 A mode can send different types of setpoints, ranging from high-level navigation tasks all the way down to direct actuator controls.
 
 Documentation:
@@ -10,7 +10,12 @@ Documentation:
 
 ## Compatibility with PX4
 The library interacts with PX4 by using its uORB messages, and thus requires a matching set of message definitions on the ROS 2 side.
-Compatibility is only guaranteed if using latest `main` on the PX4 and px4_ros2/px4_msgs side. This might change in the future.
+To ensure compatibility, you must either:
+
+1. Use latest `main` on the PX4 and px4_ros2/px4_msgs sides, which should define matching messages
+1. (Experimental) Run the PX4 [message translation node](https://github.com/PX4/PX4-Autopilot/tree/message_versioning_and_translation/msg/translation_node), which dynamically monitors and translates PX4 messages when different message version are used within the same ROS 2 domain
+
+### Option 1: Match Messages
 
 The library checks for message compatibility on startup when registering a mode.
 `ALL_PX4_ROS2_MESSAGES` defines the set of checked messages. If you use other messages, you can check them using:
@@ -24,6 +29,25 @@ To manually verify that two local versions of PX4 and px4_msgs have matching mes
 
 ```sh
 ./scripts/check-message-compatibility.py -v path/to/px4_msgs/ path/to/PX4-Autopilot/
+```
+
+### Option 2: Translate Messages
+
+If you intend to run the message translation node to use mismatching message versions in PX4 and px4_ros2/px4_msgs, then you must manually disable the message compatibility check that runs when registering a mode.
+This can be done the following way:
+
+```c++
+class CustomMode : public px4_ros2::ModeBase
+{
+public:
+  CustomMode(rclcpp::Node & node)
+  : ModeBase(node, "node_name")
+  {
+    setSkipMessageCompatibilityCheck();  // Disables compatibility check
+    ...
+  }
+  ...
+};
 ```
 
 ## Examples

--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -49,6 +49,7 @@ set(HEADER_FILES
         include/px4_ros2/utils/frame_conversion.hpp
         include/px4_ros2/utils/geodesic.hpp
         include/px4_ros2/utils/geometry.hpp
+        include/px4_ros2/utils/message_version.hpp
         include/px4_ros2/vehicle_state/battery.hpp
         include/px4_ros2/vehicle_state/home_position.hpp
         include/px4_ros2/vehicle_state/land_detected.hpp

--- a/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
@@ -162,7 +162,10 @@ public:
   RequirementFlags & modeRequirements() {return _health_and_arming_checks.modeRequirements();}
 
 protected:
-  void setSkipMessageCompatibilityCheck() {_skip_message_compatibility_check = true;}
+  void setSkipMessageCompatibilityCheck(bool skip = true)
+  {
+    _skip_message_compatibility_check = skip;
+  }
   void overrideRegistration(const std::shared_ptr<Registration> & registration);
 
 private:
@@ -191,7 +194,7 @@ private:
   std::shared_ptr<Registration> _registration;
 
   const Settings _settings;
-  bool _skip_message_compatibility_check{false};
+  bool _skip_message_compatibility_check{true};
 
   HealthAndArmingChecks _health_and_arming_checks;
 

--- a/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
@@ -162,10 +162,7 @@ public:
   RequirementFlags & modeRequirements() {return _health_and_arming_checks.modeRequirements();}
 
 protected:
-  void setSkipMessageCompatibilityCheck(bool skip = true)
-  {
-    _skip_message_compatibility_check = skip;
-  }
+  void setSkipMessageCompatibilityCheck() {_skip_message_compatibility_check = true;}
   void overrideRegistration(const std::shared_ptr<Registration> & registration);
 
 private:
@@ -194,7 +191,7 @@ private:
   std::shared_ptr<Registration> _registration;
 
   const Settings _settings;
-  bool _skip_message_compatibility_check{true};
+  bool _skip_message_compatibility_check{false};
 
   HealthAndArmingChecks _health_and_arming_checks;
 

--- a/px4_ros2_cpp/include/px4_ros2/utils/message_version.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/message_version.hpp
@@ -1,0 +1,53 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+/**
+ * @defgroup message_version Message Version
+ * @ingroup utils
+ * This group contains helper functions to handle message versioning.
+ */
+
+#pragma once
+
+#include <string>
+#include <type_traits>
+
+namespace px4_ros2
+{
+
+/**
+ * @brief Trait to check if a message type `T` has a `MESSAGE_VERSION` constant.
+ *
+ * If `T` has `MESSAGE_VERSION`, `HasMessageVersion<T>::value` is `true`;
+ * otherwise it is `false`.
+ *
+ * @tparam T The message type to check.
+ */
+template<typename T, typename = void>
+struct HasMessageVersion : std::false_type {};
+
+/// Specialization for types that have a `MESSAGE_VERSION` constant.
+template<typename T>
+struct HasMessageVersion<T, std::void_t<decltype(T::MESSAGE_VERSION)>>: std::true_type {};
+
+/**
+ * @brief Retrieves the version suffix for a given message type.
+ *
+ * @tparam T The message type, which may or may not define a `MESSAGE_VERSION` constant.
+ * @return std::string The version suffix (e.g., "_v1") or an empty string if `MESSAGE_VERSION` is `0` or undefined.
+ */
+template<typename T>
+std::string getMessageNameVersion()
+{
+  if constexpr (HasMessageVersion<T>::value) {
+    if (T::MESSAGE_VERSION == 0) {return "";}
+    return "_v" + std::to_string(T::MESSAGE_VERSION);
+  } else {
+    return "";
+  }
+}
+
+
+} // namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/vehicle_state/battery.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/vehicle_state/battery.hpp
@@ -9,6 +9,7 @@
 #include <px4_msgs/msg/battery_status.hpp>
 #include <px4_ros2/common/context.hpp>
 #include <px4_ros2/utils/subscription.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 namespace px4_ros2
 {
@@ -25,7 +26,8 @@ class Battery : public Subscription<px4_msgs::msg::BatteryStatus>
 {
 public:
   explicit Battery(Context & context)
-  : Subscription<px4_msgs::msg::BatteryStatus>(context, "fmu/out/battery_status") {}
+  : Subscription<px4_msgs::msg::BatteryStatus>(context,
+      "fmu/out/battery_status" + px4_ros2::getMessageNameVersion<px4_msgs::msg::BatteryStatus>()) {}
 
   /**
    * @brief Get the vehicle's battery voltage.

--- a/px4_ros2_cpp/include/px4_ros2/vehicle_state/home_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/vehicle_state/home_position.hpp
@@ -9,6 +9,7 @@
 #include <px4_msgs/msg/home_position.hpp>
 #include <px4_ros2/common/context.hpp>
 #include <px4_ros2/utils/subscription.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 namespace px4_ros2
 {
@@ -25,7 +26,8 @@ class HomePosition : public Subscription<px4_msgs::msg::HomePosition>
 {
 public:
   explicit HomePosition(Context & context)
-  : Subscription<px4_msgs::msg::HomePosition>(context, "fmu/out/home_position") {}
+  : Subscription<px4_msgs::msg::HomePosition>(context,
+      "fmu/out/home_position" + +px4_ros2::getMessageNameVersion<px4_msgs::msg::HomePosition>()) {}
 
   /**
    * @brief Get the vehicle's home position in local coordinates.

--- a/px4_ros2_cpp/include/px4_ros2/vehicle_state/land_detected.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/vehicle_state/land_detected.hpp
@@ -8,6 +8,7 @@
 #include <px4_msgs/msg/vehicle_land_detected.hpp>
 #include <px4_ros2/common/context.hpp>
 #include <px4_ros2/utils/subscription.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 namespace px4_ros2
 {
@@ -24,7 +25,9 @@ class LandDetected : public Subscription<px4_msgs::msg::VehicleLandDetected>
 {
 public:
   explicit LandDetected(Context & context)
-  : Subscription<px4_msgs::msg::VehicleLandDetected>(context, "fmu/out/vehicle_land_detected") {}
+  : Subscription<px4_msgs::msg::VehicleLandDetected>(context,
+      "fmu/out/vehicle_land_detected" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleLandDetected>()) {}
 
   /**
    * @brief Check if vehicle is landed on the ground.

--- a/px4_ros2_cpp/include/px4_ros2/vehicle_state/vehicle_status.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/vehicle_state/vehicle_status.hpp
@@ -8,6 +8,7 @@
 #include <px4_msgs/msg/vehicle_status.hpp>
 #include <px4_ros2/common/context.hpp>
 #include <px4_ros2/utils/subscription.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 namespace px4_ros2
 {
@@ -24,7 +25,8 @@ class VehicleStatus : public Subscription<px4_msgs::msg::VehicleStatus>
 {
 public:
   explicit VehicleStatus(Context & context)
-  : Subscription<px4_msgs::msg::VehicleStatus>(context, "fmu/out/vehicle_status") {}
+  : Subscription<px4_msgs::msg::VehicleStatus>(context,
+      "fmu/out/vehicle_status" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>()) {}
 
   /**
    * @brief Get the vehicle's arming status.

--- a/px4_ros2_cpp/include/px4_ros2/vehicle_state/vtol_status.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/vehicle_state/vtol_status.hpp
@@ -8,6 +8,7 @@
 #include <px4_msgs/msg/vtol_vehicle_status.hpp>
 #include <px4_ros2/common/context.hpp>
 #include <px4_ros2/utils/subscription.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 namespace px4_ros2
 {
@@ -24,7 +25,9 @@ class VtolStatus : public Subscription<px4_msgs::msg::VtolVehicleStatus>
 {
 public:
   explicit VtolStatus(Context & context)
-  : Subscription<px4_msgs::msg::VtolVehicleStatus>(context, "fmu/out/vtol_vehicle_status") {}
+  : Subscription<px4_msgs::msg::VtolVehicleStatus>(context,
+      "fmu/out/vtol_vehicle_status" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VtolVehicleStatus>()) {}
 
   /**
    * @brief Check if vehicle is in an undefined state. This indicates the vehicle is not a VTOL.

--- a/px4_ros2_cpp/src/components/health_and_arming_checks.cpp
+++ b/px4_ros2_cpp/src/components/health_and_arming_checks.cpp
@@ -5,6 +5,7 @@
 
 #include "registration.hpp"
 #include "px4_ros2/components/health_and_arming_checks.hpp"
+#include "px4_ros2/utils/message_version.hpp"
 
 #include <cassert>
 #include <utility>
@@ -21,10 +22,11 @@ HealthAndArmingChecks::HealthAndArmingChecks(
   _check_callback(std::move(check_callback))
 {
   _arming_check_reply_pub = _node.create_publisher<px4_msgs::msg::ArmingCheckReply>(
-    topic_namespace_prefix + "fmu/in/arming_check_reply", 1);
+    topic_namespace_prefix + "fmu/in/arming_check_reply" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ArmingCheckReply>(),
+    1);
 
   _arming_check_request_sub = _node.create_subscription<px4_msgs::msg::ArmingCheckRequest>(
-    topic_namespace_prefix + "fmu/out/arming_check_request",
+    topic_namespace_prefix + "fmu/out/arming_check_request" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ArmingCheckRequest>(),
     rclcpp::QoS(1).best_effort(),
     [this](px4_msgs::msg::ArmingCheckRequest::UniquePtr msg) {
 

--- a/px4_ros2_cpp/src/components/manual_control_input.cpp
+++ b/px4_ros2_cpp/src/components/manual_control_input.cpp
@@ -5,6 +5,7 @@
 
 #include "px4_ros2/components/manual_control_input.hpp"
 #include "px4_ros2/components/mode.hpp"
+#include "px4_ros2/utils/message_version.hpp"
 
 namespace px4_ros2
 {
@@ -16,7 +17,7 @@ ManualControlInput::ManualControlInput(Context & context, bool is_optional)
 
   _manual_control_setpoint_sub =
     context.node().create_subscription<px4_msgs::msg::ManualControlSetpoint>(
-    context.topicNamespacePrefix() + "fmu/out/manual_control_setpoint", rclcpp::QoS(
+    context.topicNamespacePrefix() + "fmu/out/manual_control_setpoint" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ManualControlSetpoint>(), rclcpp::QoS(
       1).best_effort(),
     [this](px4_msgs::msg::ManualControlSetpoint::UniquePtr msg) {
       _manual_control_setpoint = *msg;

--- a/px4_ros2_cpp/src/components/message_compatibility_check.cpp
+++ b/px4_ros2_cpp/src/components/message_compatibility_check.cpp
@@ -6,6 +6,7 @@
 #include "px4_ros2/components/message_compatibility_check.hpp"
 #include <px4_msgs/msg/message_format_request.hpp>
 #include <px4_msgs/msg/message_format_response.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 #include <string>
 #include <vector>
@@ -229,13 +230,15 @@ bool messageCompatibilityCheck(
     message_format_response_sub
     =
     node.create_subscription<px4_msgs::msg::MessageFormatResponse>(
-      topic_namespace_prefix + "fmu/out/message_format_response", rclcpp::QoS(1).best_effort(),
+      topic_namespace_prefix + "fmu/out/message_format_response" + px4_ros2::getMessageNameVersion<px4_msgs::msg::MessageFormatResponse>(), rclcpp::QoS(
+        1).best_effort(),
       [](px4_msgs::msg::MessageFormatResponse::UniquePtr msg) {});
 
   const rclcpp::Publisher<px4_msgs::msg::MessageFormatRequest>::SharedPtr message_format_request_pub
     =
     node.create_publisher<px4_msgs::msg::MessageFormatRequest>(
-      topic_namespace_prefix + "fmu/in/message_format_request", 1);
+      topic_namespace_prefix + "fmu/in/message_format_request" + px4_ros2::getMessageNameVersion<px4_msgs::msg::MessageFormatRequest>(),
+      1);
 
   const std::string msgs_dir = ament_index_cpp::get_package_share_directory("px4_msgs");
   if (msgs_dir.empty()) {

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -6,6 +6,7 @@
 #include "px4_ros2/components/mode.hpp"
 #include "px4_ros2/components/message_compatibility_check.hpp"
 #include "px4_ros2/components/wait_for_fmu.hpp"
+#include "px4_ros2/utils/message_version.hpp"
 
 #include "registration.hpp"
 
@@ -28,16 +29,19 @@ ModeBase::ModeBase(
     topic_namespace_prefix), _config_overrides(node, topic_namespace_prefix)
 {
   _vehicle_status_sub = node.create_subscription<px4_msgs::msg::VehicleStatus>(
-    topic_namespace_prefix + "fmu/out/vehicle_status", rclcpp::QoS(1).best_effort(),
+    topic_namespace_prefix + "fmu/out/vehicle_status" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
+      1).best_effort(),
     [this](px4_msgs::msg::VehicleStatus::UniquePtr msg) {
       if (_registration->registered()) {
         vehicleStatusUpdated(msg);
       }
     });
   _mode_completed_pub = node.create_publisher<px4_msgs::msg::ModeCompleted>(
-    topic_namespace_prefix + "fmu/in/mode_completed", 1);
+    topic_namespace_prefix + "fmu/in/mode_completed" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ModeCompleted>(),
+    1);
   _config_control_setpoints_pub = node.create_publisher<px4_msgs::msg::VehicleControlMode>(
-    topic_namespace_prefix + "fmu/in/config_control_setpoints", 1);
+    topic_namespace_prefix + "fmu/in/config_control_setpoints" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleControlMode>(),
+    1);
 }
 
 ModeBase::ModeID ModeBase::id() const

--- a/px4_ros2_cpp/src/components/mode_executor.cpp
+++ b/px4_ros2_cpp/src/components/mode_executor.cpp
@@ -6,6 +6,7 @@
 #include "px4_ros2/components/mode_executor.hpp"
 #include "px4_ros2/components/message_compatibility_check.hpp"
 #include "px4_ros2/components/wait_for_fmu.hpp"
+#include "px4_ros2/utils/message_version.hpp"
 
 #include "registration.hpp"
 
@@ -26,7 +27,8 @@ ModeExecutorBase::ModeExecutorBase(
   _config_overrides(node, topic_namespace_prefix)
 {
   _vehicle_status_sub = _node.create_subscription<px4_msgs::msg::VehicleStatus>(
-    topic_namespace_prefix + "fmu/out/vehicle_status", rclcpp::QoS(1).best_effort(),
+    topic_namespace_prefix + "fmu/out/vehicle_status" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
+      1).best_effort(),
     [this](px4_msgs::msg::VehicleStatus::UniquePtr msg) {
       if (_registration->registered()) {
         vehicleStatusUpdated(msg);
@@ -34,7 +36,8 @@ ModeExecutorBase::ModeExecutorBase(
     });
 
   _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
-    topic_namespace_prefix + "fmu/in/vehicle_command_mode_executor", 1);
+    topic_namespace_prefix + "fmu/in/vehicle_command_mode_executor" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
+    1);
 
 }
 
@@ -127,7 +130,8 @@ Result ModeExecutorBase::sendCommandSync(
   // (We could also use exchange_in_use_by_wait_set_state(), but that might cause an
   // inconsistent state)
   const auto vehicle_command_ack_sub = _node.create_subscription<px4_msgs::msg::VehicleCommandAck>(
-    _topic_namespace_prefix + "fmu/out/vehicle_command_ack", rclcpp::QoS(1).best_effort(),
+    _topic_namespace_prefix + "fmu/out/vehicle_command_ack" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommandAck>(), rclcpp::QoS(
+      1).best_effort(),
     [](px4_msgs::msg::VehicleCommandAck::UniquePtr msg) {});
 
   // Wait until we have a publisher
@@ -430,7 +434,8 @@ ModeExecutorBase::ScheduledMode::ScheduledMode(
   const std::string & topic_namespace_prefix)
 {
   _mode_completed_sub = node.create_subscription<px4_msgs::msg::ModeCompleted>(
-    topic_namespace_prefix + "fmu/out/mode_completed", rclcpp::QoS(1).best_effort(),
+    topic_namespace_prefix + "fmu/out/mode_completed" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ModeCompleted>(), rclcpp::QoS(
+      1).best_effort(),
     [this, &node](px4_msgs::msg::ModeCompleted::UniquePtr msg) {
       if (active() && msg->nav_state == static_cast<uint8_t>(_mode_id)) {
         RCLCPP_DEBUG(

--- a/px4_ros2_cpp/src/components/overrides.cpp
+++ b/px4_ros2_cpp/src/components/overrides.cpp
@@ -4,6 +4,7 @@
  ****************************************************************************/
 
 #include "px4_ros2/components/overrides.hpp"
+#include "px4_ros2/utils/message_version.hpp"
 
 #include <cassert>
 
@@ -14,7 +15,8 @@ ConfigOverrides::ConfigOverrides(rclcpp::Node & node, const std::string & topic_
 : _node(node)
 {
   _config_overrides_pub = _node.create_publisher<px4_msgs::msg::ConfigOverrides>(
-    topic_namespace_prefix + "fmu/in/config_overrides_request", 1);
+    topic_namespace_prefix + "fmu/in/config_overrides_request" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ConfigOverrides>(),
+    1);
 }
 
 void ConfigOverrides::controlAutoDisarm(bool enabled)

--- a/px4_ros2_cpp/src/components/registration.cpp
+++ b/px4_ros2_cpp/src/components/registration.cpp
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <random>
 #include <unistd.h>
+#include <px4_ros2/utils/message_version.hpp>
 
 static constexpr uint16_t kLatestPX4ROS2ApiVersion = 1;
 
@@ -18,17 +19,19 @@ Registration::Registration(rclcpp::Node & node, const std::string & topic_namesp
 {
   _register_ext_component_reply_sub =
     node.create_subscription<px4_msgs::msg::RegisterExtComponentReply>(
-    topic_namespace_prefix + "fmu/out/register_ext_component_reply",
+    topic_namespace_prefix + "fmu/out/register_ext_component_reply" + px4_ros2::getMessageNameVersion<px4_msgs::msg::RegisterExtComponentReply>(),
     rclcpp::QoS(1).best_effort(),
     [](px4_msgs::msg::RegisterExtComponentReply::UniquePtr msg) {
     });
 
   _register_ext_component_request_pub =
     node.create_publisher<px4_msgs::msg::RegisterExtComponentRequest>(
-    topic_namespace_prefix + "fmu/in/register_ext_component_request", 1);
+    topic_namespace_prefix + "fmu/in/register_ext_component_request" + px4_ros2::getMessageNameVersion<px4_msgs::msg::RegisterExtComponentRequest>(),
+    1);
 
   _unregister_ext_component_pub = node.create_publisher<px4_msgs::msg::UnregisterExtComponent>(
-    topic_namespace_prefix + "fmu/in/unregister_ext_component", 1);
+    topic_namespace_prefix + "fmu/in/unregister_ext_component" + px4_ros2::getMessageNameVersion<px4_msgs::msg::UnregisterExtComponent>(),
+    1);
 
   _unregister_ext_component.mode_id = px4_ros2::ModeBase::kModeIDInvalid;
 }

--- a/px4_ros2_cpp/src/components/wait_for_fmu.cpp
+++ b/px4_ros2_cpp/src/components/wait_for_fmu.cpp
@@ -5,6 +5,7 @@
 
 #include <px4_ros2/components/wait_for_fmu.hpp>
 #include <px4_msgs/msg/vehicle_status.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 namespace px4_ros2
 {
@@ -16,7 +17,8 @@ bool waitForFMU(
   RCLCPP_DEBUG(node.get_logger(), "Waiting for FMU...");
   const rclcpp::Subscription<px4_msgs::msg::VehicleStatus>::SharedPtr vehicle_status_sub =
     node.create_subscription<px4_msgs::msg::VehicleStatus>(
-    topic_namespace_prefix + "fmu/out/vehicle_status", rclcpp::QoS(1).best_effort(),
+    topic_namespace_prefix + "fmu/out/vehicle_status" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
+      1).best_effort(),
     [](px4_msgs::msg::VehicleStatus::UniquePtr msg) {});
 
   rclcpp::WaitSet wait_set;

--- a/px4_ros2_cpp/src/control/peripheral_actuators.cpp
+++ b/px4_ros2_cpp/src/control/peripheral_actuators.cpp
@@ -4,6 +4,7 @@
  ****************************************************************************/
 
 #include <px4_ros2/control/peripheral_actuators.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 using namespace std::chrono_literals;
 
@@ -14,7 +15,8 @@ PeripheralActuatorControls::PeripheralActuatorControls(Context & context)
 : _node(context.node())
 {
   _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
-    context.topicNamespacePrefix() + "fmu/in/vehicle_command", 1);
+    context.topicNamespacePrefix() + "fmu/in/vehicle_command" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
+    1);
   _last_update = _node.get_clock()->now();
 }
 

--- a/px4_ros2_cpp/src/control/setpoint_types/direct_actuators.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/direct_actuators.cpp
@@ -4,6 +4,7 @@
  ****************************************************************************/
 
 #include <px4_ros2/control/setpoint_types/direct_actuators.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 
 namespace px4_ros2
@@ -13,9 +14,11 @@ DirectActuatorsSetpointType::DirectActuatorsSetpointType(Context & context)
 : SetpointBase(context), _node(context.node())
 {
   _actuator_motors_pub = context.node().create_publisher<px4_msgs::msg::ActuatorMotors>(
-    context.topicNamespacePrefix() + "fmu/in/actuator_motors", 1);
+    context.topicNamespacePrefix() + "fmu/in/actuator_motors" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ActuatorMotors>(),
+    1);
   _actuator_servos_pub = context.node().create_publisher<px4_msgs::msg::ActuatorServos>(
-    context.topicNamespacePrefix() + "fmu/in/actuator_servos", 1);
+    context.topicNamespacePrefix() + "fmu/in/actuator_servos" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ActuatorServos>(),
+    1);
 }
 
 void DirectActuatorsSetpointType::updateMotors(

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/attitude.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/attitude.cpp
@@ -5,7 +5,7 @@
 
 #include <px4_ros2/control/setpoint_types/experimental/attitude.hpp>
 #include <px4_ros2/utils/geometry.hpp>
-
+#include <px4_ros2/utils/message_version.hpp>
 
 namespace px4_ros2
 {
@@ -15,7 +15,8 @@ AttitudeSetpointType::AttitudeSetpointType(Context & context)
 {
   _vehicle_attitude_setpoint_pub =
     context.node().create_publisher<px4_msgs::msg::VehicleAttitudeSetpoint>(
-    context.topicNamespacePrefix() + "fmu/in/vehicle_attitude_setpoint", 1);
+    context.topicNamespacePrefix() + "fmu/in/vehicle_attitude_setpoint" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleAttitudeSetpoint>(),
+    1);
 }
 
 void AttitudeSetpointType::update(

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/rates.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/rates.cpp
@@ -4,7 +4,7 @@
  ****************************************************************************/
 
 #include <px4_ros2/control/setpoint_types/experimental/rates.hpp>
-
+#include <px4_ros2/utils/message_version.hpp>
 
 namespace px4_ros2
 {
@@ -14,7 +14,8 @@ RatesSetpointType::RatesSetpointType(Context & context)
 {
   _vehicle_rates_setpoint_pub =
     context.node().create_publisher<px4_msgs::msg::VehicleRatesSetpoint>(
-    context.topicNamespacePrefix() + "fmu/in/vehicle_rates_setpoint", 1);
+    context.topicNamespacePrefix() + "fmu/in/vehicle_rates_setpoint" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleRatesSetpoint>(),
+    1);
 }
 
 void RatesSetpointType::update(

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/trajectory.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/trajectory.cpp
@@ -4,7 +4,7 @@
  ****************************************************************************/
 
 #include <px4_ros2/control/setpoint_types/experimental/trajectory.hpp>
-
+#include <px4_ros2/utils/message_version.hpp>
 
 namespace px4_ros2
 {
@@ -13,7 +13,8 @@ TrajectorySetpointType::TrajectorySetpointType(Context & context)
 : SetpointBase(context), _node(context.node())
 {
   _trajectory_setpoint_pub = context.node().create_publisher<px4_msgs::msg::TrajectorySetpoint>(
-    context.topicNamespacePrefix() + "fmu/in/trajectory_setpoint", 1);
+    context.topicNamespacePrefix() + "fmu/in/trajectory_setpoint" + px4_ros2::getMessageNameVersion<px4_msgs::msg::TrajectorySetpoint>(),
+    1);
 }
 
 void TrajectorySetpointType::update(

--- a/px4_ros2_cpp/src/control/setpoint_types/goto.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/goto.cpp
@@ -4,6 +4,7 @@
  ****************************************************************************/
 
 #include <px4_ros2/control/setpoint_types/goto.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 
 namespace px4_ros2
@@ -14,7 +15,8 @@ GotoSetpointType::GotoSetpointType(Context & context)
 {
   _goto_setpoint_pub =
     context.node().create_publisher<px4_msgs::msg::GotoSetpoint>(
-    context.topicNamespacePrefix() + "fmu/in/goto_setpoint", 1);
+    context.topicNamespacePrefix() + "fmu/in/goto_setpoint" + px4_ros2::getMessageNameVersion<px4_msgs::msg::GotoSetpoint>(),
+    1);
 }
 
 void GotoSetpointType::update(

--- a/px4_ros2_cpp/src/navigation/experimental/global_position_measurement_interface.cpp
+++ b/px4_ros2_cpp/src/navigation/experimental/global_position_measurement_interface.cpp
@@ -4,6 +4,7 @@
  ****************************************************************************/
 
 #include <px4_ros2/navigation/experimental/global_position_measurement_interface.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 using Eigen::Vector2d;
 using px4_msgs::msg::VehicleGlobalPosition;
@@ -16,7 +17,8 @@ GlobalPositionMeasurementInterface::GlobalPositionMeasurementInterface(rclcpp::N
 {
   _aux_global_position_pub =
     node.create_publisher<VehicleGlobalPosition>(
-    topicNamespacePrefix() + "fmu/in/aux_global_position", 10);
+    topicNamespacePrefix() + "fmu/in/aux_global_position" + px4_ros2::getMessageNameVersion<VehicleGlobalPosition>(),
+    10);
 }
 
 void GlobalPositionMeasurementInterface::update(

--- a/px4_ros2_cpp/src/navigation/experimental/local_position_measurement_interface.cpp
+++ b/px4_ros2_cpp/src/navigation/experimental/local_position_measurement_interface.cpp
@@ -5,6 +5,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <px4_ros2/navigation/experimental/local_position_measurement_interface.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 using Eigen::Vector2f, Eigen::Quaternionf, Eigen::Vector3f;
 
@@ -19,7 +20,8 @@ LocalPositionMeasurementInterface::LocalPositionMeasurementInterface(
   _velocity_frame(velocityFrameToMessageFrame(velocity_frame))
 {
   _aux_local_position_pub = node.create_publisher<AuxLocalPosition>(
-    topicNamespacePrefix() + "fmu/in/vehicle_visual_odometry", 10);
+    topicNamespacePrefix() + "fmu/in/vehicle_visual_odometry" + px4_ros2::getMessageNameVersion<AuxLocalPosition>(),
+    10);
 }
 
 void LocalPositionMeasurementInterface::update(

--- a/px4_ros2_cpp/src/odometry/angular_velocity.cpp
+++ b/px4_ros2_cpp/src/odometry/angular_velocity.cpp
@@ -4,12 +4,15 @@
  ****************************************************************************/
 
 #include <px4_ros2/odometry/angular_velocity.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 namespace px4_ros2
 {
 
 OdometryAngularVelocity::OdometryAngularVelocity(Context & context)
-: Subscription<px4_msgs::msg::VehicleAngularVelocity>(context, "fmu/out/vehicle_angular_velocity")
+: Subscription<px4_msgs::msg::VehicleAngularVelocity>(context,
+    "fmu/out/vehicle_angular_velocity" +
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleAngularVelocity>())
 {
   RequirementFlags requirements{};
   requirements.angular_velocity = true;

--- a/px4_ros2_cpp/src/odometry/attitude.cpp
+++ b/px4_ros2_cpp/src/odometry/attitude.cpp
@@ -4,12 +4,14 @@
  ****************************************************************************/
 
 #include <px4_ros2/odometry/attitude.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 namespace px4_ros2
 {
 
 OdometryAttitude::OdometryAttitude(Context & context)
-: Subscription<px4_msgs::msg::VehicleAttitude>(context, "fmu/out/vehicle_attitude")
+: Subscription<px4_msgs::msg::VehicleAttitude>(context,
+    "fmu/out/vehicle_attitude" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleAttitude>())
 {
   RequirementFlags requirements{};
   requirements.attitude = true;

--- a/px4_ros2_cpp/src/odometry/global_position.cpp
+++ b/px4_ros2_cpp/src/odometry/global_position.cpp
@@ -4,12 +4,15 @@
  ****************************************************************************/
 
 #include <px4_ros2/odometry/global_position.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 namespace px4_ros2
 {
 
 OdometryGlobalPosition::OdometryGlobalPosition(Context & context)
-: Subscription<px4_msgs::msg::VehicleGlobalPosition>(context, "fmu/out/vehicle_global_position")
+: Subscription<px4_msgs::msg::VehicleGlobalPosition>(context,
+    "fmu/out/vehicle_global_position" +
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleGlobalPosition>())
 {
   RequirementFlags requirements{};
   requirements.global_position = true;

--- a/px4_ros2_cpp/src/odometry/local_position.cpp
+++ b/px4_ros2_cpp/src/odometry/local_position.cpp
@@ -4,12 +4,15 @@
  ****************************************************************************/
 
 #include <px4_ros2/odometry/local_position.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 namespace px4_ros2
 {
 
 OdometryLocalPosition::OdometryLocalPosition(Context & context)
-: Subscription<px4_msgs::msg::VehicleLocalPosition>(context, "fmu/out/vehicle_local_position")
+: Subscription<px4_msgs::msg::VehicleLocalPosition>(context,
+    "fmu/out/vehicle_local_position" +
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleLocalPosition>())
 {
   RequirementFlags requirements{};
   requirements.local_position = true;

--- a/px4_ros2_cpp/src/utils/geodesic.cpp
+++ b/px4_ros2_cpp/src/utils/geodesic.cpp
@@ -4,6 +4,7 @@
  ****************************************************************************/
 
 #include <px4_ros2/utils/geodesic.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 #include "map_projection_impl.hpp"
 
@@ -15,7 +16,8 @@ MapProjection::MapProjection(Context & context)
 {
   _map_projection_math = std::make_unique<MapProjectionImpl>();
   _vehicle_local_position_sub = _node.create_subscription<px4_msgs::msg::VehicleLocalPosition>(
-    "fmu/out/vehicle_local_position", rclcpp::QoS(1).best_effort(),
+    "fmu/out/vehicle_local_position" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleLocalPosition>(), rclcpp::QoS(
+      1).best_effort(),
     [this](px4_msgs::msg::VehicleLocalPosition::UniquePtr msg) {
       vehicleLocalPositionCallback(std::move(msg));
     });

--- a/px4_ros2_cpp/test/integration/global_navigation.cpp
+++ b/px4_ros2_cpp/test/integration/global_navigation.cpp
@@ -16,6 +16,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <px4_msgs/msg/estimator_status_flags.hpp>
 #include <px4_ros2/navigation/experimental/global_position_measurement_interface.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 #include "util.hpp"
 
 using namespace std::chrono_literals;
@@ -35,7 +36,8 @@ protected:
 
     // Subscribe to PX4 EKF estimator status flags
     _subscriber = _node->create_subscription<EstimatorStatusFlags>(
-      "fmu/out/estimator_status_flags", rclcpp::QoS(10).best_effort(),
+      "fmu/out/estimator_status_flags" + px4_ros2::getMessageNameVersion<EstimatorStatusFlags>(), rclcpp::QoS(
+        10).best_effort(),
       [this](EstimatorStatusFlags::UniquePtr msg) {
         _estimator_status_flags = std::move(msg);
       });

--- a/px4_ros2_cpp/test/integration/local_navigation.cpp
+++ b/px4_ros2_cpp/test/integration/local_navigation.cpp
@@ -19,6 +19,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <px4_msgs/msg/estimator_status_flags.hpp>
 #include <px4_ros2/navigation/experimental/local_position_measurement_interface.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 #include "util.hpp"
 
 using namespace std::chrono_literals;
@@ -40,7 +41,8 @@ protected:
 
     // Subscribe to PX4 EKF estimator status flags
     _subscriber = _node->create_subscription<EstimatorStatusFlags>(
-      "fmu/out/estimator_status_flags", rclcpp::QoS(10).best_effort(),
+      "fmu/out/estimator_status_flags" + px4_ros2::getMessageNameVersion<EstimatorStatusFlags>(), rclcpp::QoS(
+        10).best_effort(),
       [this](EstimatorStatusFlags::UniquePtr msg) {
         _estimator_status_flags = std::move(msg);
       });

--- a/px4_ros2_cpp/test/integration/util.cpp
+++ b/px4_ros2_cpp/test/integration/util.cpp
@@ -5,6 +5,7 @@
 
 #include "util.hpp"
 #include <gtest/gtest.h>
+#include <px4_ros2/utils/message_version.hpp>
 
 std::shared_ptr<rclcpp::Node> initNode()
 {
@@ -25,8 +26,10 @@ std::shared_ptr<rclcpp::Node> initNode()
 VehicleState::VehicleState(rclcpp::Node & node, const std::string & topic_namespace_prefix)
 : _node(node)
 {
+  const std::string vehicle_status_topic = topic_namespace_prefix + "fmu/out/vehicle_status" +
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>();
   _vehicle_status_sub = _node.create_subscription<px4_msgs::msg::VehicleStatus>(
-    topic_namespace_prefix + "fmu/out/vehicle_status", rclcpp::QoS(1).best_effort(),
+    vehicle_status_topic, rclcpp::QoS(1).best_effort(),
     [this](px4_msgs::msg::VehicleStatus::UniquePtr msg) {
       if (_on_vehicle_status_update) {
         _on_vehicle_status_update(msg);
@@ -42,8 +45,10 @@ VehicleState::VehicleState(rclcpp::Node & node, const std::string & topic_namesp
       }
     });
 
+  const std::string vehicle_command_topic = topic_namespace_prefix + "fmu/in/vehicle_command" +
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>();
   _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
-    topic_namespace_prefix + "fmu/in/vehicle_command", 1);
+    vehicle_command_topic, 1);
 
 }
 

--- a/px4_ros2_cpp/test/unit/global_navigation.cpp
+++ b/px4_ros2_cpp/test/unit/global_navigation.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 #include <rclcpp/rclcpp.hpp>
 #include <px4_ros2/navigation/experimental/global_position_measurement_interface.hpp>
+#include <px4_ros2/utils/message_version.hpp>
 
 using px4_ros2::GlobalPositionMeasurement, px4_ros2::NavigationInterfaceInvalidArgument;
 using namespace std::chrono_literals;
@@ -41,7 +42,8 @@ protected:
       *_node);
     _subscriber =
       _node->create_subscription<px4_msgs::msg::VehicleGlobalPosition>(
-      "/fmu/in/aux_global_position", rclcpp::QoS(10).best_effort(),
+      "/fmu/in/aux_global_position" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleGlobalPosition>(), rclcpp::QoS(
+        10).best_effort(),
       [this](px4_msgs::msg::VehicleGlobalPosition::UniquePtr msg) {
         _update_msg = std::move(msg);
       });


### PR DESCRIPTION
### Changes
- Apply message version suffix to all FMU topics

### Testing
- Tested with example goto node built with a different version of `VehicleLocalPosition` than PX4 in SITL
- Translation node (tested after rebase too) implemented a direct translation between the two topic message version
- Messages transferred properly

### Note
Kept the message compatibility check as the default at the moment. Since the message translation node is not merged yet, I've marked the translation node option as "experimental" in the readme, and kept message matching as the default way to use the px4-ros2 lib for the time being