### PR TITLE
Node with mode executor and multiple modes

### DIFF
--- a/examples/cpp/modes/executor_with_multiple_modes/CMakeLists.txt
+++ b/examples/cpp/modes/executor_with_multiple_modes/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.5)
+project(example_executor_with_multiple_modes_cpp)
+
+if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter)
+endif()
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+find_package(eigen3_cmake_module REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(px4_ros2_cpp REQUIRED)
+
+include_directories(include ${Eigen3_INCLUDE_DIRS})
+add_executable(example_executor_with_multiple_modes
+        src/main.cpp)
+ament_target_dependencies(example_executor_with_multiple_modes Eigen3 px4_ros2_cpp rclcpp)
+
+install(TARGETS
+        example_executor_with_multiple_modes
+        DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+    find_package(ament_lint_auto REQUIRED)
+    ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/examples/cpp/modes/executor_with_multiple_modes/include/executor.hpp
+++ b/examples/cpp/modes/executor_with_multiple_modes/include/executor.hpp
@@ -1,0 +1,96 @@
+/****************************************************************************
+ * Copyright (c) 2023 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+#pragma once
+
+#include <modes.hpp>
+#include <px4_ros2/components/mode_executor.hpp>
+
+class ModeExecutorTest : public px4_ros2::ModeExecutorBase
+{
+public:
+  ModeExecutorTest(rclcpp::Node & node, px4_ros2::ModeBase & owned_mode, px4_ros2::ModeBase & second_mode, px4_ros2::ModeBase & third_mode)
+  : ModeExecutorBase(node, px4_ros2::ModeExecutorBase::Settings{}, owned_mode),
+    _node(node), _second_mode(second_mode), _third_mode(third_mode)
+  {
+  }
+
+  enum class State
+  {
+    Reset,
+    TakingOff,
+    MyFirstMode,
+    MySecondMode,
+    MyThirdMode,
+    RTL,
+    WaitUntilDisarmed,
+  };
+
+  void onActivate() override
+  {
+    runState(State::TakingOff, px4_ros2::Result::Success);
+  }
+
+  void onDeactivate(DeactivateReason reason) override
+  {
+  }
+
+  void runState(State state, px4_ros2::Result previous_result)
+  {
+    if (previous_result != px4_ros2::Result::Success) {
+      RCLCPP_ERROR(
+        _node.get_logger(), "State %i: previous state failed: %s", (int)state,
+        resultToString(previous_result));
+      return;
+    }
+
+    RCLCPP_DEBUG(_node.get_logger(), "Executing state %i", (int)state);
+
+    switch (state) {
+      case State::Reset:
+        break;
+
+      case State::TakingOff:
+        takeoff([this](px4_ros2::Result result) {runState(State::MyFirstMode, result);});
+        break;
+
+      case State::MyFirstMode:
+        scheduleMode(
+          ownedMode().id(), [this](px4_ros2::Result result) {
+            runState(State::MySecondMode, result);
+          });
+        break;
+
+      case State::MySecondMode:
+        scheduleMode(
+          _second_mode.id(), [this](px4_ros2::Result result) {
+            runState(State::MyThirdMode, result);
+          });
+        break;
+
+      case State::MyThirdMode:
+        scheduleMode(
+          _third_mode.id(), [this](px4_ros2::Result result) {
+            runState(State::RTL, result);
+          });
+        break;
+
+      case State::RTL:
+        rtl([this](px4_ros2::Result result) {runState(State::WaitUntilDisarmed, result);});
+        break;
+
+      case State::WaitUntilDisarmed:
+        waitUntilDisarmed(
+          [this](px4_ros2::Result result) {
+            RCLCPP_INFO(_node.get_logger(), "All states complete (%s)", resultToString(result));
+          });
+        break;
+    }
+  }
+
+private:
+  rclcpp::Node & _node;
+  px4_ros2::ModeBase & _second_mode;
+  px4_ros2::ModeBase & _third_mode;
+};

--- a/examples/cpp/modes/executor_with_multiple_modes/include/executor.hpp
+++ b/examples/cpp/modes/executor_with_multiple_modes/include/executor.hpp
@@ -10,7 +10,9 @@
 class ModeExecutorTest : public px4_ros2::ModeExecutorBase
 {
 public:
-  ModeExecutorTest(rclcpp::Node & node, px4_ros2::ModeBase & owned_mode, px4_ros2::ModeBase & second_mode, px4_ros2::ModeBase & third_mode)
+  ModeExecutorTest(
+    rclcpp::Node & node, px4_ros2::ModeBase & owned_mode,
+    px4_ros2::ModeBase & second_mode, px4_ros2::ModeBase & third_mode)
   : ModeExecutorBase(node, px4_ros2::ModeExecutorBase::Settings{}, owned_mode),
     _node(node), _second_mode(second_mode), _third_mode(third_mode)
   {

--- a/examples/cpp/modes/executor_with_multiple_modes/include/mode.hpp
+++ b/examples/cpp/modes/executor_with_multiple_modes/include/mode.hpp
@@ -1,0 +1,218 @@
+/****************************************************************************
+ * Copyright (c) 2023 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+#pragma once
+
+#include <px4_ros2/components/mode.hpp>
+#include <px4_ros2/components/mode_executor.hpp>
+#include <px4_ros2/components/wait_for_fmu.hpp>
+#include <px4_ros2/control/setpoint_types/experimental/trajectory.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <Eigen/Core>
+
+using namespace std::chrono_literals; // NOLINT
+
+static const std::string kNameFirst = "Auto-Executor-Start";
+static const std::string kNameSecond = "Auto-Executor-Segment";
+static const std::string kNameThird = "Auto-Executor-End";
+
+class FlightModeTestStart : public px4_ros2::ModeBase
+{
+public:
+  explicit FlightModeTestStart(rclcpp::Node & node)
+  : ModeBase(node, Settings{kNameFirst, false})
+  {
+    _trajectory_setpoint = std::make_shared<px4_ros2::TrajectorySetpointType>(*this);
+  }
+
+  ~FlightModeTestStart() override = default;
+
+  void onActivate() override
+  {
+    _activation_time = node().get_clock()->now();
+  }
+
+  void onDeactivate() override {}
+
+  void updateSetpoint(float dt_s) override
+  {
+    const rclcpp::Time now = node().get_clock()->now();
+
+    if (now - _activation_time > 5s) {
+      completed(px4_ros2::Result::Success);
+      return;
+    }
+
+    const float elapsed_s = (now - _activation_time).seconds();
+    const Eigen::Vector3f velocity{10.f, elapsed_s * 2.f, -2.f};
+    _trajectory_setpoint->update(velocity);
+  }
+
+private:
+  rclcpp::Time _activation_time{};
+  std::shared_ptr<px4_ros2::TrajectorySetpointType> _trajectory_setpoint;
+};
+
+class FlightModeTestSegment : public px4_ros2::ModeBase
+{
+public:
+  explicit FlightModeTestSegment(rclcpp::Node & node)
+  : ModeBase(node, Settings{kNameSecond, false})
+  {
+    _trajectory_setpoint = std::make_shared<px4_ros2::TrajectorySetpointType>(*this);
+  }
+
+  ~FlightModeTestSegment() override = default;
+
+  void onActivate() override
+  {
+    _activation_time = node().get_clock()->now();
+  }
+
+  void onDeactivate() override {}
+
+  void updateSetpoint(float dt_s) override
+  {
+    const rclcpp::Time now = node().get_clock()->now();
+
+    if (now - _activation_time > 5s) {
+      completed(px4_ros2::Result::Success);
+      return;
+    }
+
+    const float elapsed_s = (now - _activation_time).seconds();
+    const Eigen::Vector3f velocity{10.f, -elapsed_s * 2.f, 2.f};
+    _trajectory_setpoint->update(velocity);
+  }
+
+private:
+  rclcpp::Time _activation_time{};
+  std::shared_ptr<px4_ros2::TrajectorySetpointType> _trajectory_setpoint;
+};
+
+class FlightModeTestEnd : public px4_ros2::ModeBase
+{
+public:
+  explicit FlightModeTestEnd(rclcpp::Node & node)
+  : ModeBase(node, Settings{kNameThird, false})
+  {
+    _trajectory_setpoint = std::make_shared<px4_ros2::TrajectorySetpointType>(*this);
+  }
+
+  ~FlightModeTestEnd() override = default;
+
+  void onActivate() override
+  {
+    _activation_time = node().get_clock()->now();
+  }
+
+  void onDeactivate() override {}
+
+  void updateSetpoint(float dt_s) override
+  {
+    const rclcpp::Time now = node().get_clock()->now();
+
+    if (now - _activation_time > 5s) {
+      completed(px4_ros2::Result::Success);
+      return;
+    }
+
+    const Eigen::Vector3f velocity{-10.f, 0, 0};
+    _trajectory_setpoint->update(velocity);
+  }
+
+private:
+  rclcpp::Time _activation_time{};
+  std::shared_ptr<px4_ros2::TrajectorySetpointType> _trajectory_setpoint;
+};
+
+class ModeExecutorTest : public px4_ros2::ModeExecutorBase
+{
+public:
+  ModeExecutorTest(rclcpp::Node & node, px4_ros2::ModeBase & owned_mode, px4_ros2::ModeBase & second_mode, px4_ros2::ModeBase & third_mode)
+  : ModeExecutorBase(node, px4_ros2::ModeExecutorBase::Settings{}, owned_mode),
+    _node(node), _second_mode(second_mode), _third_mode(third_mode)
+  {
+  }
+
+  enum class State
+  {
+    Reset,
+    TakingOff,
+    MyFirstMode,
+    MySecondMode,
+    MyThirdMode,
+    RTL,
+    WaitUntilDisarmed,
+  };
+
+  void onActivate() override
+  {
+    runState(State::TakingOff, px4_ros2::Result::Success);
+  }
+
+  void onDeactivate(DeactivateReason reason) override
+  {
+  }
+
+  void runState(State state, px4_ros2::Result previous_result)
+  {
+    if (previous_result != px4_ros2::Result::Success) {
+      RCLCPP_ERROR(
+        _node.get_logger(), "State %i: previous state failed: %s", (int)state,
+        resultToString(previous_result));
+      return;
+    }
+
+    RCLCPP_DEBUG(_node.get_logger(), "Executing state %i", (int)state);
+
+    switch (state) {
+      case State::Reset:
+        break;
+
+      case State::TakingOff:
+        takeoff([this](px4_ros2::Result result) {runState(State::MyFirstMode, result);});
+        break;
+
+      case State::MyFirstMode:
+        scheduleMode(
+          ownedMode().id(), [this](px4_ros2::Result result) {
+            runState(State::MySecondMode, result);
+          });
+        break;
+
+      case State::MySecondMode:
+        scheduleMode(
+          _second_mode.id(), [this](px4_ros2::Result result) {
+            runState(State::MyThirdMode, result);
+          });
+        break;
+
+      case State::MyThirdMode:
+        scheduleMode(
+          _third_mode.id(), [this](px4_ros2::Result result) {
+            runState(State::RTL, result);
+          });
+        break;
+
+      case State::RTL:
+        rtl([this](px4_ros2::Result result) {runState(State::WaitUntilDisarmed, result);});
+        break;
+
+      case State::WaitUntilDisarmed:
+        waitUntilDisarmed(
+          [this](px4_ros2::Result result) {
+            RCLCPP_INFO(_node.get_logger(), "All states complete (%s)", resultToString(result));
+          });
+        break;
+    }
+  }
+
+private:
+  rclcpp::Node & _node;
+  px4_ros2::ModeBase & _second_mode;
+  px4_ros2::ModeBase & _third_mode;
+};

--- a/examples/cpp/modes/executor_with_multiple_modes/include/modes.hpp
+++ b/examples/cpp/modes/executor_with_multiple_modes/include/modes.hpp
@@ -5,8 +5,7 @@
 #pragma once
 
 #include <px4_ros2/components/mode.hpp>
-#include <px4_ros2/components/mode_executor.hpp>
-#include <px4_ros2/components/wait_for_fmu.hpp>
+#include <px4_ros2/control/setpoint_types/experimental/rates.hpp>
 #include <px4_ros2/control/setpoint_types/experimental/trajectory.hpp>
 
 #include <rclcpp/rclcpp.hpp>
@@ -62,7 +61,7 @@ public:
   explicit FlightModeTestSegment(rclcpp::Node & node)
   : ModeBase(node, Settings{kNameSecond, false})
   {
-    _trajectory_setpoint = std::make_shared<px4_ros2::TrajectorySetpointType>(*this);
+    _rates_setpoint = std::make_shared<px4_ros2::RatesSetpointType>(*this);
   }
 
   ~FlightModeTestSegment() override = default;
@@ -78,19 +77,19 @@ public:
   {
     const rclcpp::Time now = node().get_clock()->now();
 
-    if (now - _activation_time > 5s) {
+    if (now - _activation_time > 500ms) {
       completed(px4_ros2::Result::Success);
       return;
     }
 
-    const float elapsed_s = (now - _activation_time).seconds();
-    const Eigen::Vector3f velocity{10.f, -elapsed_s * 2.f, 2.f};
-    _trajectory_setpoint->update(velocity);
+    const Eigen::Vector3f rate{10.f, 0.f, 0.f};
+    const Eigen::Vector3f thrust{0.f, 0.f, -0.5f};
+    _rates_setpoint->update(rate, thrust);
   }
 
 private:
   rclcpp::Time _activation_time{};
-  std::shared_ptr<px4_ros2::TrajectorySetpointType> _trajectory_setpoint;
+  std::shared_ptr<px4_ros2::RatesSetpointType> _rates_setpoint;
 };
 
 class FlightModeTestEnd : public px4_ros2::ModeBase
@@ -120,99 +119,12 @@ public:
       return;
     }
 
-    const Eigen::Vector3f velocity{-10.f, 0, 0};
+    const float elapsed_s = (now - _activation_time).seconds();
+    const Eigen::Vector3f velocity{-10.f, -elapsed_s * 2.f, 0.f};
     _trajectory_setpoint->update(velocity);
   }
 
 private:
   rclcpp::Time _activation_time{};
   std::shared_ptr<px4_ros2::TrajectorySetpointType> _trajectory_setpoint;
-};
-
-class ModeExecutorTest : public px4_ros2::ModeExecutorBase
-{
-public:
-  ModeExecutorTest(rclcpp::Node & node, px4_ros2::ModeBase & owned_mode, px4_ros2::ModeBase & second_mode, px4_ros2::ModeBase & third_mode)
-  : ModeExecutorBase(node, px4_ros2::ModeExecutorBase::Settings{}, owned_mode),
-    _node(node), _second_mode(second_mode), _third_mode(third_mode)
-  {
-  }
-
-  enum class State
-  {
-    Reset,
-    TakingOff,
-    MyFirstMode,
-    MySecondMode,
-    MyThirdMode,
-    RTL,
-    WaitUntilDisarmed,
-  };
-
-  void onActivate() override
-  {
-    runState(State::TakingOff, px4_ros2::Result::Success);
-  }
-
-  void onDeactivate(DeactivateReason reason) override
-  {
-  }
-
-  void runState(State state, px4_ros2::Result previous_result)
-  {
-    if (previous_result != px4_ros2::Result::Success) {
-      RCLCPP_ERROR(
-        _node.get_logger(), "State %i: previous state failed: %s", (int)state,
-        resultToString(previous_result));
-      return;
-    }
-
-    RCLCPP_DEBUG(_node.get_logger(), "Executing state %i", (int)state);
-
-    switch (state) {
-      case State::Reset:
-        break;
-
-      case State::TakingOff:
-        takeoff([this](px4_ros2::Result result) {runState(State::MyFirstMode, result);});
-        break;
-
-      case State::MyFirstMode:
-        scheduleMode(
-          ownedMode().id(), [this](px4_ros2::Result result) {
-            runState(State::MySecondMode, result);
-          });
-        break;
-
-      case State::MySecondMode:
-        scheduleMode(
-          _second_mode.id(), [this](px4_ros2::Result result) {
-            runState(State::MyThirdMode, result);
-          });
-        break;
-
-      case State::MyThirdMode:
-        scheduleMode(
-          _third_mode.id(), [this](px4_ros2::Result result) {
-            runState(State::RTL, result);
-          });
-        break;
-
-      case State::RTL:
-        rtl([this](px4_ros2::Result result) {runState(State::WaitUntilDisarmed, result);});
-        break;
-
-      case State::WaitUntilDisarmed:
-        waitUntilDisarmed(
-          [this](px4_ros2::Result result) {
-            RCLCPP_INFO(_node.get_logger(), "All states complete (%s)", resultToString(result));
-          });
-        break;
-    }
-  }
-
-private:
-  rclcpp::Node & _node;
-  px4_ros2::ModeBase & _second_mode;
-  px4_ros2::ModeBase & _third_mode;
 };

--- a/examples/cpp/modes/executor_with_multiple_modes/include/modes.hpp
+++ b/examples/cpp/modes/executor_with_multiple_modes/include/modes.hpp
@@ -114,13 +114,13 @@ public:
   {
     const rclcpp::Time now = node().get_clock()->now();
 
-    if (now - _activation_time > 5s) {
+    if (now - _activation_time > 10s) {
       completed(px4_ros2::Result::Success);
       return;
     }
 
-    const float elapsed_s = (now - _activation_time).seconds();
-    const Eigen::Vector3f velocity{-10.f, -elapsed_s * 2.f, 0.f};
+    const unsigned int elapsed_s = static_cast<unsigned int>((now - _activation_time).seconds());
+    const Eigen::Vector3f velocity{-10.f, (elapsed_s % 3 - 1) * 2.f, 0.f};
     _trajectory_setpoint->update(velocity);
   }
 

--- a/examples/cpp/modes/executor_with_multiple_modes/package.xml
+++ b/examples/cpp/modes/executor_with_multiple_modes/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>example_executor_with_multiple_modes_cpp</name>
+  <version>0.0.1</version>
+  <description>Example: Executor with multiple modes</description>
+  <maintainer email="beat-kueng@gmx.net">Beat Kueng</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
+
+  <build_depend>eigen</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_export_depend>eigen</build_export_depend>
+
+  <depend>px4_ros2_cpp</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/examples/cpp/modes/executor_with_multiple_modes/src/main.cpp
+++ b/examples/cpp/modes/executor_with_multiple_modes/src/main.cpp
@@ -1,0 +1,22 @@
+/****************************************************************************
+ * Copyright (c) 2023 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#include "rclcpp/rclcpp.hpp"
+
+#include <mode.hpp>
+#include <px4_ros2/components/node_with_mode.hpp>
+
+using MyNodeWithModeExecutor = px4_ros2::NodeWithModeExecutor<ModeExecutorTest, FlightModeTestStart, FlightModeTestSegment, FlightModeTestEnd>;
+
+static const std::string kNodeName = "example_executor_with_multiple_modes";
+static const bool kEnableDebugOutput = true;
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<MyNodeWithModeExecutor>(kNodeName, kEnableDebugOutput));
+  rclcpp::shutdown();
+  return 0;
+}

--- a/examples/cpp/modes/executor_with_multiple_modes/src/main.cpp
+++ b/examples/cpp/modes/executor_with_multiple_modes/src/main.cpp
@@ -8,7 +8,8 @@
 #include <executor.hpp>
 #include <px4_ros2/components/node_with_mode.hpp>
 
-using MyNodeWithModeExecutor = px4_ros2::NodeWithModeExecutor<ModeExecutorTest, FlightModeTestStart, FlightModeTestSegment, FlightModeTestEnd>;
+using MyNodeWithModeExecutor = px4_ros2::NodeWithModeExecutor<ModeExecutorTest, FlightModeTestStart,
+    FlightModeTestSegment, FlightModeTestEnd>;
 
 static const std::string kNodeName = "example_executor_with_multiple_modes";
 static const bool kEnableDebugOutput = true;

--- a/examples/cpp/modes/executor_with_multiple_modes/src/main.cpp
+++ b/examples/cpp/modes/executor_with_multiple_modes/src/main.cpp
@@ -5,7 +5,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include <mode.hpp>
+#include <executor.hpp>
 #include <px4_ros2/components/node_with_mode.hpp>
 
 using MyNodeWithModeExecutor = px4_ros2::NodeWithModeExecutor<ModeExecutorTest, FlightModeTestStart, FlightModeTestSegment, FlightModeTestEnd>;

--- a/px4_ros2_cpp/include/px4_ros2/components/node_with_mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/node_with_mode.hpp
@@ -142,7 +142,7 @@ public:
   }
 
   template<typename ModeT>
-  OwnedModeT & getMode() const
+  ModeT & getMode() const
   {
     return *std::get<ModeT>(_other_modes);
   }

--- a/px4_ros2_cpp/include/px4_ros2/components/node_with_mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/node_with_mode.hpp
@@ -123,16 +123,6 @@ public:
     }
   }
 
-  template<std::size_t... Idx>
-  auto createModeExecutor(std::index_sequence<Idx...>)
-  {
-    if constexpr (sizeof...(Idx) == 0) {
-      return std::make_unique<ModeExecutorT>(*this, *_owned_mode);
-    } else {
-      return std::make_unique<ModeExecutorT>(*this, *_owned_mode, *std::get<Idx>(_other_modes)...);
-    }
-  }
-
   template<typename ModeT = OwnedModeT>
   ModeT & getMode() const
   {
@@ -144,6 +134,16 @@ public:
   }
 
 private:
+  template<std::size_t... Idx>
+  auto createModeExecutor(std::index_sequence<Idx...>)
+  {
+    if constexpr (sizeof...(Idx) == 0) {
+      return std::make_unique<ModeExecutorT>(*this, *_owned_mode);
+    } else {
+      return std::make_unique<ModeExecutorT>(*this, *_owned_mode, *std::get<Idx>(_other_modes)...);
+    }
+  }
+
   std::unique_ptr<ModeExecutorT> _mode_executor;
   std::unique_ptr<OwnedModeT> _owned_mode;
   std::tuple<std::unique_ptr<OtherModesT>...> _other_modes;

--- a/px4_ros2_cpp/include/px4_ros2/components/node_with_mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/node_with_mode.hpp
@@ -93,7 +93,7 @@ class NodeWithModeExecutor : public rclcpp::Node
     std::is_base_of_v<ModeExecutorBase, ModeExecutorT>,
     "Template type ModeExecutorT must be derived from px4_ros2::ModeExecutorBase");
   static_assert(
-    (std::is_base_of_v<ModeBase, OwnedModeT> && ... && std::is_base_of_v<ModeBase, OtherModesT>),
+    (std::is_base_of_v<ModeBase, OwnedModeT>&& ... && std::is_base_of_v<ModeBase, OtherModesT>),
     "Template types OwnedModeT and OtherModesT must be derived from px4_ros2::ModeBase");
 
 public:
@@ -116,7 +116,9 @@ public:
 
     if (!_mode_executor->doRegister() || !std::apply(
         [](const auto &... mode) {
+          // *INDENT-OFF*
           return (mode->doRegister() && ...);
+          // *INDENT-ON*
         }, _other_modes))
     {
       throw std::runtime_error("Registration failed");


### PR DESCRIPTION
I added a variadic template parameter to the `NodeWithModeExecutor` to enable registering of multiple custom modes with one node and easily access their ids from within the executor. The behavior of the class has not changed if just one mode is passed as template parameter. For each additional mode a unique_ptr of the optional modes will be generated and saved in a tuple. All modes of the tuple will be registered together with the executor. The executor itself must take the additional modes as constructor arguments, as is already the case with the owned mode.

The provided example (`example_executor_with_multiple_modes`) has two additional modes in comparison to the mode-with-executor example, so three custom modes in total:

1. Auto-Executor-Start doing the same as in the mode-with-executor example. This mode is owned by the executor.
2. Auto-Executor-Segment doing a flip with roll setpoints.
3. Auto-Executor-End flying in a zig-zag pattern.