### PR TITLE
fw-ctrl: allow setting any subset of control limits.

### DIFF
--- a/px4_ros2_cpp/src/control/setpoint_types/fixedwing/fw_control_setpoint.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/fixedwing/fw_control_setpoint.cpp
@@ -67,44 +67,23 @@ namespace px4_ros2
     _fw_longitudinal_control_sp_pub->publish(lon_sp);
 
 	px4_msgs::msg::LateralControlLimits lat_limits{};
-	bool publish_lat_limits =  !std::isnan(max_lat_acc.value());
-	
-	if (publish_lat_limits) {
-		lat_limits.lateral_accel_max = *max_lat_acc;
+	lat_limits.lateral_accel_max = *max_lat_acc;
 
-		lat_limits.timestamp = _node.get_clock()->now().nanoseconds() / 1000;
-		_lateral_control_limits_pub->publish(lat_limits);
-	}
+	lat_limits.timestamp = _node.get_clock()->now().nanoseconds() / 1000;
+	_lateral_control_limits_pub->publish(lat_limits);
 
 	px4_msgs::msg::LongitudinalControlLimits lon_limits{};
+	lon_limits.pitch_min = *min_pitch;
+	lon_limits.pitch_max = *max_pitch;
+	lon_limits.throttle_min = *min_throttle;
+	lon_limits.throttle_max = *max_throttle;
+	lon_limits.equivalent_airspeed_min = *min_EAS;
+	lon_limits.equivalent_airspeed_max = *max_EAS;
+	lon_limits.climb_rate_target = *target_climb_rate;
+	lon_limits.sink_rate_target = *target_sink_rate;
 
-	bool publish_lon_limits = !std::isnan(min_pitch.value()) && !std::isnan(max_pitch.value()) &&
-		!std::isnan(min_throttle.value()) && !std::isnan(max_throttle.value()) &&
-		!std::isnan(min_EAS.value()) && !std::isnan(max_EAS.value()) &&
-		!std::isnan(target_climb_rate.value()) && !std::isnan(target_sink_rate.value());
-	
-	bool incomplete_lon_limits = !publish_lon_limits && 
-		(!std::isnan(min_pitch.value()) || !std::isnan(max_pitch.value()) ||
-		!std::isnan(min_throttle.value()) || !std::isnan(max_throttle.value()) ||
-		!std::isnan(min_EAS.value()) || !std::isnan(max_EAS.value()) ||
-		!std::isnan(target_climb_rate.value()) || !std::isnan(target_sink_rate.value()));
-
-	if (publish_lon_limits) {
-		lon_limits.pitch_min = *min_pitch;
-		lon_limits.pitch_max = *max_pitch;
-		lon_limits.throttle_min = *min_throttle;
-		lon_limits.throttle_max = *max_throttle;
-		lon_limits.equivalent_airspeed_min = *min_EAS;
-		lon_limits.equivalent_airspeed_max = *max_EAS;
-		lon_limits.climb_rate_target = *target_climb_rate;
-		lon_limits.sink_rate_target = *target_sink_rate;
-
-		lon_limits.timestamp = _node.get_clock()->now().nanoseconds() / 1000;
-		_longitudinal_control_limits_pub->publish(lon_limits);
-	} else if (incomplete_lon_limits) {
-		// Log warning if incomplete limits are set
-		RCLCPP_WARN_ONCE(_node.get_logger(), "Incomplete longitudinal control limits set. Using default PX4 limits.");
-	}
+	lon_limits.timestamp = _node.get_clock()->now().nanoseconds() / 1000;
+	_longitudinal_control_limits_pub->publish(lon_limits);
 	}
 
     SetpointBase::Configuration FwControlSetpointType::getConfiguration()


### PR DESCRIPTION
Following commit in fw-ctrl-api branch in px4:  https://github.com/PX4/PX4-Autopilot/pull/24056/commits/55be9648e8438eb1e6ca1387fab6276313751f80

Removed check that all control limits need to be set for publishing.  