### PR TITLE
Make TrajectorySetpointType more flexible

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/trajectory.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/trajectory.hpp
@@ -16,6 +16,8 @@ namespace px4_ros2
  *  @{
  */
 
+struct TrajectorySetpoint;
+
 /**
  * @brief Setpoint type for trajectory control
  *
@@ -37,6 +39,18 @@ public:
     std::optional<float> yaw_rate_ned_rad_s = {});
 
   /**
+   * @brief Update the setpoint with full flexibility by passing a TrajectorySetpoint
+   *
+   * @param setpoint a TrajectorySetpoint object where position, velocity and acceleration
+   * can be set individually for full flexibility
+   *
+   * @warning This method is not recommended for general use because it is possible
+   * to set contradicting setpoint values that can result in an unstable system
+   * and to crashes.
+   */
+  void update(const TrajectorySetpoint & setpoint);
+
+  /**
    * @brief Position setpoint update.
    *
    * The GotoSetpointType should be preferred.
@@ -52,4 +66,244 @@ private:
 };
 
 /** @}*/
+
+
+/**
+ * @brief Setpoint structure for trajectory control with fine-grained control over individual components
+ *
+ * This structure allows setting position, velocity, acceleration, yaw, and yaw rate
+ * individually on a per-axis basis. All fields are optional which means unset fields will
+ * not be controlled (NaN values will be sent to PX4).
+ *
+ * @warning Combining certain types of setpoints (e.g., position and velocity on the same axis)
+ * can lead to inconsistencies and unstable behavior. Use with caution.
+ *
+ * @note For simple position control, use TrajectorySetpointType::updatePosition() instead, or even
+ * better, use the GotoSetpointTypeif possible.
+ *
+ * ## Example: Altitude hold with horizontal velocity
+ * ```cpp
+ * TrajectorySetpoint setpoint;
+ * setpoint.withHorizontalVelocity(Eigen::Vector2f(1.0f, 0.5f)) // Move at 1 m/s forward, 0.5 m/s right
+ *         .withPositionZ(-2.0f);                               // Hold altitude at 2 meters above ground
+ * trajectory_setpoint_type->update(setpoint);
+ * ```
+ */
+struct TrajectorySetpoint
+{
+  std::optional<float> position_ned_m_x;
+  std::optional<float> position_ned_m_y;
+  std::optional<float> position_ned_m_z;
+
+  std::optional<float> velocity_ned_m_s_x;
+  std::optional<float> velocity_ned_m_s_y;
+  std::optional<float> velocity_ned_m_s_z;
+
+  std::optional<float> acceleration_ned_m_s2_x;
+  std::optional<float> acceleration_ned_m_s2_y;
+  std::optional<float> acceleration_ned_m_s2_z;
+
+  std::optional<float> yaw_ned_rad;
+  std::optional<float> yaw_rate_ned_rad_s;
+
+
+  /**
+   * @brief Set position setpoint for x-axis in NED frame
+   * @param x_ned_m Position in x-axis [m]
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withPositionX(float x_ned_m)
+  {
+    position_ned_m_x = x_ned_m;
+    return *this;
+  }
+
+  /**
+   * @brief Set position setpoint for y-axis in NED frame
+   * @param y_ned_m Position in y-axis [m]
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withPositionY(float y_ned_m)
+  {
+    position_ned_m_y = y_ned_m;
+    return *this;
+  }
+
+  /**
+   * @brief Set position setpoint for z-axis in NED frame
+   * @param z_ned_m Position in z-axis [m] (negative = above ground in NED frame)
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withPositionZ(float z_ned_m)
+  {
+    position_ned_m_z = z_ned_m;
+    return *this;
+  }
+
+  /**
+   * @brief Set velocity setpoint for x-axis in NED frame
+   * @param x_ned_m_s Velocity in x-axis [m/s]
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withVelocityX(float x_ned_m_s)
+  {
+    velocity_ned_m_s_x = x_ned_m_s;
+    return *this;
+  }
+
+  /**
+   * @brief Set velocity setpoint for y-axis in NED frame
+   * @param y_ned_m_s Velocity in y-axis [m/s]
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withVelocityY(float y_ned_m_s)
+  {
+    velocity_ned_m_s_y = y_ned_m_s;
+    return *this;
+  }
+
+  /**
+   * @brief Set velocity setpoint for z-axis in NED frame
+   * @param z_ned_m_s Velocity in z-axis [m/s] (negative = upward in NED frame)
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withVelocityZ(float z_ned_m_s)
+  {
+    velocity_ned_m_s_z = z_ned_m_s;
+    return *this;
+  }
+
+  /**
+   * @brief Set acceleration setpoint for x-axis in NED frame
+   * @param x_ned_m_s2 Acceleration in x-axis [m/s²]
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withAccelerationX(float x_ned_m_s2)
+  {
+    acceleration_ned_m_s2_x = x_ned_m_s2;
+    return *this;
+  }
+
+  /**
+   * @brief Set acceleration setpoint for y-axis in NED frame
+   * @param y_ned_m_s2 Acceleration in y-axis [m/s²]
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withAccelerationY(float y_ned_m_s2)
+  {
+    acceleration_ned_m_s2_y = y_ned_m_s2;
+    return *this;
+  }
+
+  /**
+   * @brief Set acceleration setpoint for z-axis in NED frame
+   * @param z_ned_m_s2 Acceleration in z-axis [m/s²] (negative = upward in NED frame)
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withAccelerationZ(float z_ned_m_s2)
+  {
+    acceleration_ned_m_s2_z = z_ned_m_s2;
+    return *this;
+  }
+
+  /**
+   * @brief Set yaw setpoint in NED frame
+   * @param yaw_rad Yaw angle [rad] (0 = North, PI/2 = East)
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withYaw(float yaw_rad)
+  {
+    this->yaw_ned_rad = yaw_rad;
+    return *this;
+  }
+
+  /**
+   * @brief Set yaw rate setpoint in NED frame
+   * @param rate_rad_s Yaw angular velocity [rad/s]
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withYawRate(float rate_rad_s)
+  {
+    this->yaw_rate_ned_rad_s = rate_rad_s;
+    return *this;
+  }
+
+  // Helper methods for setting multiple components at once
+  /**
+   * @brief Set position setpoint for all axes (x, y, z) in NED frame
+   * @param position_ned_m Position vector in NED frame [m]
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withPosition(const Eigen::Vector3f & position_ned_m)
+  {
+    position_ned_m_x = position_ned_m.x();
+    position_ned_m_y = position_ned_m.y();
+    position_ned_m_z = position_ned_m.z();
+    return *this;
+  }
+
+  /**
+   * @brief Set position setpoint for horizontal axes (x, y) in NED frame
+   * @param position_ned_m Position vector in NE plane [m]
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withHorizontalPosition(const Eigen::Vector2f & position_ned_m)
+  {
+    position_ned_m_x = position_ned_m.x();
+    position_ned_m_y = position_ned_m.y();
+    return *this;
+  }
+
+  /**
+   * @brief Set velocity setpoint for all axes (x, y, z) in NED frame
+   * @param velocity_ned_m_s Velocity vector in NED frame [m/s]
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withVelocity(const Eigen::Vector3f & velocity_ned_m_s)
+  {
+    velocity_ned_m_s_x = velocity_ned_m_s.x();
+    velocity_ned_m_s_y = velocity_ned_m_s.y();
+    velocity_ned_m_s_z = velocity_ned_m_s.z();
+    return *this;
+  }
+
+  /**
+   * @brief Set velocity setpoint for horizontal axes (x, y) in NED frame
+   * @param velocity_ned_m_s Velocity vector in NE plane [m/s]
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withHorizontalVelocity(const Eigen::Vector2f & velocity_ned_m_s)
+  {
+    velocity_ned_m_s_x = velocity_ned_m_s.x();
+    velocity_ned_m_s_y = velocity_ned_m_s.y();
+    return *this;
+  }
+
+  /**
+   * @brief Set acceleration setpoint for all axes (x, y, z) in NED frame
+   * @param acceleration_ned_m_s2 Acceleration vector in NED frame [m/s²]
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withAcceleration(const Eigen::Vector3f & acceleration_ned_m_s2)
+  {
+    acceleration_ned_m_s2_x = acceleration_ned_m_s2.x();
+    acceleration_ned_m_s2_y = acceleration_ned_m_s2.y();
+    acceleration_ned_m_s2_z = acceleration_ned_m_s2.z();
+    return *this;
+  }
+
+  /**
+   * @brief Set acceleration setpoint for horizontal axes (x, y) in NED frame
+   * @param acceleration_ned_m_s2 Acceleration vector in NE plane [m/s²]
+   * @return Reference to self for method chaining
+   */
+  TrajectorySetpoint & withHorizontalAcceleration(const Eigen::Vector2f & acceleration_ned_m_s2)
+  {
+    acceleration_ned_m_s2_x = acceleration_ned_m_s2.x();
+    acceleration_ned_m_s2_y = acceleration_ned_m_s2.y();
+    return *this;
+  }
+};
+
+
 } /* namespace px4_ros2 */

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/trajectory.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/trajectory.cpp
@@ -13,7 +13,8 @@ TrajectorySetpointType::TrajectorySetpointType(Context & context)
 : SetpointBase(context), _node(context.node())
 {
   _trajectory_setpoint_pub = context.node().create_publisher<px4_msgs::msg::TrajectorySetpoint>(
-    context.topicNamespacePrefix() + "fmu/in/trajectory_setpoint" + px4_ros2::getMessageNameVersion<px4_msgs::msg::TrajectorySetpoint>(),
+    context.topicNamespacePrefix() + "fmu/in/trajectory_setpoint" +
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::TrajectorySetpoint>(),
     1);
 }
 
@@ -38,6 +39,28 @@ void TrajectorySetpointType::update(
   sp.acceleration[2] = acceleration.z();
   sp.yaw = yaw_ned_rad.value_or(NAN);
   sp.yawspeed = yaw_rate_ned_rad_s.value_or(NAN);
+
+  _trajectory_setpoint_pub->publish(sp);
+}
+
+void TrajectorySetpointType::update(const TrajectorySetpoint & setpoint)
+{
+  onUpdate();
+
+  px4_msgs::msg::TrajectorySetpoint sp{};
+  sp.timestamp = 0; // Let PX4 set the timestamp
+
+  sp.position[0] = setpoint.position_ned_m_x.value_or(NAN);
+  sp.position[1] = setpoint.position_ned_m_y.value_or(NAN);
+  sp.position[2] = setpoint.position_ned_m_z.value_or(NAN);
+  sp.velocity[0] = setpoint.velocity_ned_m_s_x.value_or(NAN);
+  sp.velocity[1] = setpoint.velocity_ned_m_s_y.value_or(NAN);
+  sp.velocity[2] = setpoint.velocity_ned_m_s_z.value_or(NAN);
+  sp.acceleration[0] = setpoint.acceleration_ned_m_s2_x.value_or(NAN);
+  sp.acceleration[1] = setpoint.acceleration_ned_m_s2_y.value_or(NAN);
+  sp.acceleration[2] = setpoint.acceleration_ned_m_s2_z.value_or(NAN);
+  sp.yaw = setpoint.yaw_ned_rad.value_or(NAN);
+  sp.yawspeed = setpoint.yaw_rate_ned_rad_s.value_or(NAN);
 
   _trajectory_setpoint_pub->publish(sp);
 }


### PR DESCRIPTION
Hey @bkueng I made an attempt at implementing what we discussed in #78 

This makes the TrajectorySetpointType more flexible by allowing the user to set position, velocity, acceleration, yaw, and yaw rate individually. For this we introduce a new helper struct TrajectorySetpoint with a builder pattern to set the different values.

I might have overdone it by making all fields individually settable through the builder pattern but I thought it would be more convenient than having to mix field access and builder pattern.

We tested this really quickly in simulation and it seems to work.

Let me know if you want me to change anything.