### PR TITLE
fix: global position interface test

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/odometry/global_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/global_position.hpp
@@ -25,6 +25,14 @@ public:
   explicit OdometryGlobalPosition(Context & context);
 
   /**
+   * Check if the last vehicle's global position is valid.
+   */
+  bool positionValid() const
+  {
+    return lastValid() && last().lat_lon_valid && last().alt_valid;
+  }
+
+  /**
    * @brief Get the vehicle's global position.
    *
    * @returns a vector of (latitude [°], longitude [°], altitude [m AMSL])

--- a/px4_ros2_cpp/test/integration/global_navigation.cpp
+++ b/px4_ros2_cpp/test/integration/global_navigation.cpp
@@ -17,10 +17,12 @@
 #include <px4_msgs/msg/estimator_status_flags.hpp>
 #include <px4_ros2/navigation/experimental/global_position_measurement_interface.hpp>
 #include <px4_ros2/utils/message_version.hpp>
+#include <px4_ros2/odometry/global_position.hpp>
 #include "util.hpp"
 
 using namespace std::chrono_literals;
-using px4_ros2::GlobalPositionMeasurement, px4_ros2::GlobalPositionMeasurementInterface;
+using px4_ros2::GlobalPositionMeasurement, px4_ros2::GlobalPositionMeasurementInterface,
+px4_ros2::OdometryGlobalPosition;
 using px4_msgs::msg::EstimatorStatusFlags;
 
 class GlobalPositionInterfaceTest : public BaseTest
@@ -31,6 +33,8 @@ protected:
     _node = initNode();
 
     _global_navigation_interface = std::make_shared<GlobalPositionMeasurementInterface>(*_node);
+    _position_interface = std::make_shared<OdometryGlobalPosition>(*_global_navigation_interface);
+
     ASSERT_TRUE(_global_navigation_interface->doRegister()) <<
       "Failed to register GlobalPositionMeasurementInterface.";
 
@@ -72,18 +76,8 @@ protected:
 
     // Wait for PX4 estimator flags to confirm proper measurement fusion
     while (!_estimator_status_flags || !is_fused_getter(_estimator_status_flags)) {
-
-      // Send measurement
-      measurement->timestamp_sample = _node->get_clock()->now();
-      ASSERT_NO_THROW(
-        _global_navigation_interface->update(*measurement)
-      ) << "Failed to send position measurement update via GlobalPositionMeasurementInterface.";
-
-      rclcpp::spin_some(_node);
-
       // Check timeout
       const auto elapsed_time = _node->now() - start_time;
-
       if (elapsed_time >= kTimeoutDuration) {
         ASSERT_NE(_estimator_status_flags, nullptr) <<
           "Missing feedback from PX4: no estimator status flags published over fmu/out/estimator_status_flags.";
@@ -92,7 +86,14 @@ protected:
         break;
       }
 
+      // Send measurement
+      measurement->timestamp_sample = _node->get_clock()->now();
+      ASSERT_NO_THROW(
+        _global_navigation_interface->update(*measurement)
+      ) << "Failed to send position measurement update via GlobalPositionMeasurementInterface.";
+
       rclcpp::sleep_for(kSleepInterval);
+      rclcpp::spin_some(_node);
     }
 
     waitUntilFlagsReset();
@@ -100,18 +101,34 @@ protected:
 
   std::shared_ptr<rclcpp::Node> _node;
   std::shared_ptr<GlobalPositionMeasurementInterface> _global_navigation_interface;
+  std::shared_ptr<OdometryGlobalPosition> _position_interface;
   rclcpp::Subscription<EstimatorStatusFlags>::SharedPtr _subscriber;
   EstimatorStatusFlags::UniquePtr _estimator_status_flags;
 
-  static constexpr std::chrono::seconds kTimeoutDuration = 60s;
+  static constexpr std::chrono::seconds kTimeoutDuration = 30s;
   static constexpr std::chrono::milliseconds kSleepInterval = 50ms;
 };
 
 TEST_F(GlobalPositionInterfaceTest, fuseAll) {
   auto measurement = std::make_unique<GlobalPositionMeasurement>();
-  measurement->lat_lon = Eigen::Vector2d {12.34567, 23.45678};
+
+  // Wait for the vehicle position
+  auto start_time = _node->now();
+  while (!_position_interface->positionValid()) {
+    // Check timeout
+    if (_node->now() - start_time >= kTimeoutDuration) {
+      FAIL() << "Timeout while waiting for position to be valid.";
+      break;
+    }
+
+    rclcpp::spin_some(_node);
+    rclcpp::sleep_for(kSleepInterval);
+  }
+  const auto position = _position_interface->position();
+
+  measurement->lat_lon = Eigen::Vector2d {position.x(), position.y()};
   measurement->horizontal_variance = 0.01F;
-  measurement->altitude_msl = 123.f;
+  measurement->altitude_msl = position.z();
   measurement->vertical_variance = 0.01F;
   waitForMeasurementUpdate(
     std::move(measurement), [](const EstimatorStatusFlags::UniquePtr & flags) {


### PR DESCRIPTION
Fixes integration test that was sending out hardcoded global positioning, causing the EKF to reject the injected position.

Tested with https://github.com/PX4/PX4-Autopilot/pull/24658
