### PR TITLE
added possibility to force avoiding local position checks

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/common/requirement_flags.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/common/requirement_flags.hpp
@@ -59,6 +59,7 @@ struct RequirementFlags
   bool home_position{false};
   bool prevent_arming{false}; ///< If set, arming is prevented when the mode is selected
   bool manual_control{false};
+  bool local_position_is_optional{false};
 };
 
 } // namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/common/requirement_flags.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/common/requirement_flags.hpp
@@ -59,7 +59,6 @@ struct RequirementFlags
   bool home_position{false};
   bool prevent_arming{false}; ///< If set, arming is prevented when the mode is selected
   bool manual_control{false};
-  bool local_position_is_optional{false};
 };
 
 } // namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/common/setpoint_base.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/common/setpoint_base.hpp
@@ -42,7 +42,7 @@ public:
     bool acceleration_enabled{true};
     bool velocity_enabled{true};
     bool position_enabled{true};
-
+    bool local_position_is_optional{false};
     bool climb_rate_enabled{false};
   };
 

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/trajectory.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/trajectory.hpp
@@ -26,7 +26,12 @@ struct TrajectorySetpoint;
 class TrajectorySetpointType : public SetpointBase
 {
 public:
-  explicit TrajectorySetpointType(Context & context);
+  explicit TrajectorySetpointType(Context & context, bool local_position_is_optional = false);
+  /**
+   * setting local_position_is_optional to true allows to create a mode that uses trajectory 
+   * setpoint but doesn't necessarly require local position. Sending XY position setpoint 
+   * without a correct source of positional data is not recommended
+   */
 
   ~TrajectorySetpointType() override = default;
 
@@ -63,6 +68,8 @@ public:
 private:
   rclcpp::Node & _node;
   rclcpp::Publisher<px4_msgs::msg::TrajectorySetpoint>::SharedPtr _trajectory_setpoint_pub;
+
+  bool _local_position_is_optional;
 };
 
 /** @}*/

--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/trajectory.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/trajectory.hpp
@@ -26,12 +26,13 @@ struct TrajectorySetpoint;
 class TrajectorySetpointType : public SetpointBase
 {
 public:
-  explicit TrajectorySetpointType(Context & context, bool local_position_is_optional = false);
+
   /**
    * setting local_position_is_optional to true allows to create a mode that uses trajectory 
    * setpoint but doesn't necessarly require local position. Sending XY position setpoint 
    * without a correct source of positional data is not recommended
    */
+  explicit TrajectorySetpointType(Context & context, bool local_position_is_optional = false);
 
   ~TrajectorySetpointType() override = default;
 
@@ -69,7 +70,7 @@ private:
   rclcpp::Node & _node;
   rclcpp::Publisher<px4_msgs::msg::TrajectorySetpoint>::SharedPtr _trajectory_setpoint_pub;
 
-  bool _local_position_is_optional;
+  const bool _local_position_is_optional;
 };
 
 /** @}*/

--- a/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
@@ -22,7 +22,13 @@ namespace px4_ros2
 class OdometryLocalPosition : public Subscription<px4_msgs::msg::VehicleLocalPosition>
 {
 public:
-  explicit OdometryLocalPosition(Context & context);
+  explicit OdometryLocalPosition(Context & context, bool local_position_is_optional = false);
+  /**
+   * setting local_position_is_optional to true allows to create a mode that uses local position 
+   * data but doesn't necessarly require local position to be available (for instance if the mode reads
+   * altitude data from vehicle_local_position). Reading XY position without a correct source of 
+   * positional data is not recommended 
+   */
 
   bool positionXYValid() const
   {

--- a/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/odometry/local_position.hpp
@@ -22,13 +22,14 @@ namespace px4_ros2
 class OdometryLocalPosition : public Subscription<px4_msgs::msg::VehicleLocalPosition>
 {
 public:
-  explicit OdometryLocalPosition(Context & context, bool local_position_is_optional = false);
+  
   /**
    * setting local_position_is_optional to true allows to create a mode that uses local position 
    * data but doesn't necessarly require local position to be available (for instance if the mode reads
    * altitude data from vehicle_local_position). Reading XY position without a correct source of 
    * positional data is not recommended 
    */
+  explicit OdometryLocalPosition(Context & context, bool local_position_is_optional = false);
 
   bool positionXYValid() const
   {

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -251,16 +251,11 @@ void ModeBase::updateModeRequirementsFromSetpoints()
     requirements.angular_velocity |= config.rates_enabled;
     requirements.attitude |= config.attitude_enabled;
     requirements.local_alt |= config.altitude_enabled;
-    requirements.local_position |= config.velocity_enabled;
-    requirements.local_position |= config.position_enabled;
     requirements.local_alt |= config.climb_rate_enabled;
 
     if (!config.local_position_is_optional) {
         requirements.local_position |= config.velocity_enabled;
         requirements.local_position |= config.position_enabled;
-    }
-    else {
-      requirements.local_position = false;
     }
   }
 

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -256,7 +256,7 @@ void ModeBase::updateModeRequirementsFromSetpoints()
     requirements.local_alt |= config.climb_rate_enabled;
 
     if (config.local_position_is_optional) {
-    requirements.local_position = false;
+      requirements.local_position = false;
     }
   }
 

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -254,6 +254,10 @@ void ModeBase::updateModeRequirementsFromSetpoints()
     requirements.local_position |= config.velocity_enabled;
     requirements.local_position |= config.position_enabled;
     requirements.local_alt |= config.climb_rate_enabled;
+
+    if (config.local_position_is_optional) {
+    requirements.local_position = false;
+    }
   }
 
   if (requirements.manual_control) {

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -255,7 +255,11 @@ void ModeBase::updateModeRequirementsFromSetpoints()
     requirements.local_position |= config.position_enabled;
     requirements.local_alt |= config.climb_rate_enabled;
 
-    if (config.local_position_is_optional) {
+    if (!config.local_position_is_optional) {
+        requirements.local_position |= config.velocity_enabled;
+        requirements.local_position |= config.position_enabled;
+    }
+    else {
       requirements.local_position = false;
     }
   }

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/trajectory.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/trajectory.cpp
@@ -9,9 +9,10 @@
 namespace px4_ros2
 {
 
-TrajectorySetpointType::TrajectorySetpointType(Context & context)
+TrajectorySetpointType::TrajectorySetpointType(Context & context, bool local_position_is_optional)
 : SetpointBase(context), _node(context.node())
 {
+  _local_position_is_optional = local_position_is_optional;
   _trajectory_setpoint_pub = context.node().create_publisher<px4_msgs::msg::TrajectorySetpoint>(
     context.topicNamespacePrefix() + "fmu/in/trajectory_setpoint" +
     px4_ros2::getMessageNameVersion<px4_msgs::msg::TrajectorySetpoint>(),
@@ -90,8 +91,16 @@ SetpointBase::Configuration TrajectorySetpointType::getConfiguration()
   config.rates_enabled = true;
   config.attitude_enabled = true;
   config.acceleration_enabled = true;
-  config.velocity_enabled = true;
-  config.position_enabled = true;
+
+  if(!_local_position_is_optional){
+    config.position_enabled = true;
+    config.velocity_enabled = true;
+  }
+  else {
+    config.position_enabled = false;
+    config.velocity_enabled = false;
+  }
+  
   config.altitude_enabled = true;
   config.climb_rate_enabled = true;
   return config;

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/trajectory.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/trajectory.cpp
@@ -10,9 +10,8 @@ namespace px4_ros2
 {
 
 TrajectorySetpointType::TrajectorySetpointType(Context & context, bool local_position_is_optional)
-: SetpointBase(context), _node(context.node())
+: SetpointBase(context), _node(context.node()), _local_position_is_optional(local_position_is_optional)
 {
-  _local_position_is_optional = local_position_is_optional;
   _trajectory_setpoint_pub = context.node().create_publisher<px4_msgs::msg::TrajectorySetpoint>(
     context.topicNamespacePrefix() + "fmu/in/trajectory_setpoint" +
     px4_ros2::getMessageNameVersion<px4_msgs::msg::TrajectorySetpoint>(),
@@ -91,18 +90,11 @@ SetpointBase::Configuration TrajectorySetpointType::getConfiguration()
   config.rates_enabled = true;
   config.attitude_enabled = true;
   config.acceleration_enabled = true;
-
-  if(!_local_position_is_optional){
-    config.position_enabled = true;
-    config.velocity_enabled = true;
-  }
-  else {
-    config.position_enabled = false;
-    config.velocity_enabled = false;
-  }
-  
+  config.position_enabled = true;
+  config.velocity_enabled = true;
   config.altitude_enabled = true;
   config.climb_rate_enabled = true;
+  config.local_position_is_optional = _local_position_is_optional;
   return config;
 }
 } // namespace px4_ros2

--- a/px4_ros2_cpp/src/odometry/local_position.cpp
+++ b/px4_ros2_cpp/src/odometry/local_position.cpp
@@ -9,13 +9,15 @@
 namespace px4_ros2
 {
 
-OdometryLocalPosition::OdometryLocalPosition(Context & context)
+OdometryLocalPosition::OdometryLocalPosition(Context & context, bool local_position_is_optional)
 : Subscription<px4_msgs::msg::VehicleLocalPosition>(context,
     "fmu/out/vehicle_local_position" +
     px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleLocalPosition>())
 {
   RequirementFlags requirements{};
-  requirements.local_position = true;
+  if (!local_position_is_optional) {
+    requirements.local_position = true;
+  }
   requirements.local_alt = true;
   context.setRequirement(requirements);
 }


### PR DESCRIPTION
Added the possibility, when declaring the mode requirements in the mode constructor, to specify to avoid the local position checks. 

The need for this option is to implement a mode similar to altitude mode in PX4. For this scope we need to send local position setpoints on the Z axis and horizontal acceleration setpoints on X and Y (which practically map directly to angle setpoint in PX4). So this mode is angle-controlled in XY and position-controlled on Z. This mode should therefore work with just a valid altitude estimate and not the full local position validity. With this option the user can specify to avoid local position checks and force the drone to switch to the mode when only altitude is valid.

This is the solution I came up with but if you have idea on improvements that can be made or other ways to do the same please feel free to advise.