### PR TITLE
Use ZYX sequence for quaternion to euler angle conversion

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/utils/geometry.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/geometry.hpp
@@ -142,34 +142,24 @@ Eigen::Quaternion<Type> eulerRpyToQuaternion(const Type roll, const Type pitch, 
  * @brief Convert quaternion to roll angle in extrinsic RPY order (intrinsic YPR)
  *
  * @param q The input quaternion
- * @return Roll angle corresponding to the given quaternion in range [-pi, pi]
+ * @return Roll angle corresponding to the given quaternion in range [-pi/2, pi/2]
 */
 template<typename Type>
 Type quaternionToRoll(const Eigen::Quaternion<Type> & q)
 {
-  Type x = q.x();
-  Type y = q.y();
-  Type z = q.z();
-  Type w = q.w();
-
-  return std::atan2(2.0 * (w * x + y * z), w * w - x * x - y * y + z * z);
+  return quaternionToEulerRpy(q)[0];
 }
 
 /**
  * @brief Convert quaternion to pitch angle in extrinsic RPY order (intrinsic YPR)
  *
  * @param q The input quaternion
- * @return Pitch angle corresponding to the given quaternion in range [-pi, pi]
+ * @return Pitch angle corresponding to the given quaternion in range [-pi/2, pi/2]
 */
 template<typename Type>
 Type quaternionToPitch(const Eigen::Quaternion<Type> & q)
 {
-  Type x = q.x();
-  Type y = q.y();
-  Type z = q.z();
-  Type w = q.w();
-
-  return std::atan2(2.0 * (w * y - z * x), 1.0 - 2.0 * (x * x + y * y));
+  return quaternionToEulerRpy(q)[1];
 }
 
 /**
@@ -181,12 +171,7 @@ Type quaternionToPitch(const Eigen::Quaternion<Type> & q)
 template<typename Type>
 Type quaternionToYaw(const Eigen::Quaternion<Type> & q)
 {
-  Type x = q.x();
-  Type y = q.y();
-  Type z = q.z();
-  Type w = q.w();
-
-  return std::atan2(2.0 * (x * y + w * z), w * w + x * x - y * y - z * z);
+  return quaternionToEulerRpy(q)[0];
 }
 
 /** @}*/

--- a/px4_ros2_cpp/include/px4_ros2/utils/geometry.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/geometry.hpp
@@ -142,7 +142,7 @@ Eigen::Quaternion<Type> eulerRpyToQuaternion(const Type roll, const Type pitch, 
  * @brief Convert quaternion to roll angle in extrinsic RPY order (intrinsic YPR)
  *
  * @param q The input quaternion
- * @return Roll angle corresponding to the given quaternion in range [-pi/2, pi/2]
+ * @return Roll angle corresponding to the given quaternion in range [-pi, pi]
 */
 template<typename Type>
 Type quaternionToRoll(const Eigen::Quaternion<Type> & q)
@@ -171,7 +171,7 @@ Type quaternionToPitch(const Eigen::Quaternion<Type> & q)
 template<typename Type>
 Type quaternionToYaw(const Eigen::Quaternion<Type> & q)
 {
-  return quaternionToEulerRpy(q)[0];
+  return quaternionToEulerRpy(q)[2];
 }
 
 /** @}*/


### PR DESCRIPTION
This PR allows to switch to ZYX conversion when converting quaternion to euler angles. There are no issues with the current conversion when the drone is in normal flying conditions (non tilted). However the computation diverges completely from reality when the drone is upside down. 

A good angle computation when upside down is particularly useful in specific modes such a turtle mode (ability to flip the drone when this is upside down) therefore I propose to switch to the ZYX computation as proposed in this PR