### PR TITLE
Added possibility to disarm the drone from a mode executor

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
@@ -98,7 +98,7 @@ public:
   void rtl(const CompletedCallback & on_completed);
 
   void arm(const CompletedCallback & on_completed);
-  void disarm(const CompletedCallback & on_completed, const bool & forced = false);
+  void disarm(const CompletedCallback & on_completed, bool forced = false);
   void waitReadyToArm(const CompletedCallback & on_completed);
   void waitUntilDisarmed(const CompletedCallback & on_completed);
 

--- a/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
@@ -98,6 +98,7 @@ public:
   void rtl(const CompletedCallback & on_completed);
 
   void arm(const CompletedCallback & on_completed);
+  void disarm(const CompletedCallback & on_completed, const bool & forced = false);
   void waitReadyToArm(const CompletedCallback & on_completed);
   void waitUntilDisarmed(const CompletedCallback & on_completed);
 

--- a/px4_ros2_cpp/src/components/health_and_arming_checks.cpp
+++ b/px4_ros2_cpp/src/components/health_and_arming_checks.cpp
@@ -22,11 +22,13 @@ HealthAndArmingChecks::HealthAndArmingChecks(
   _check_callback(std::move(check_callback))
 {
   _arming_check_reply_pub = _node.create_publisher<px4_msgs::msg::ArmingCheckReply>(
-    topic_namespace_prefix + "fmu/in/arming_check_reply" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ArmingCheckReply>(),
+    topic_namespace_prefix + "fmu/in/arming_check_reply" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::ArmingCheckReply>(),
     1);
 
   _arming_check_request_sub = _node.create_subscription<px4_msgs::msg::ArmingCheckRequest>(
-    topic_namespace_prefix + "fmu/out/arming_check_request" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ArmingCheckRequest>(),
+    topic_namespace_prefix + "fmu/out/arming_check_request" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::ArmingCheckRequest>(),
     rclcpp::QoS(1).best_effort(),
     [this](px4_msgs::msg::ArmingCheckRequest::UniquePtr msg) {
 

--- a/px4_ros2_cpp/src/components/health_and_arming_checks.cpp
+++ b/px4_ros2_cpp/src/components/health_and_arming_checks.cpp
@@ -23,12 +23,12 @@ HealthAndArmingChecks::HealthAndArmingChecks(
 {
   _arming_check_reply_pub = _node.create_publisher<px4_msgs::msg::ArmingCheckReply>(
     topic_namespace_prefix + "fmu/in/arming_check_reply" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::ArmingCheckReply>(),
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::ArmingCheckReply>(),
     1);
 
   _arming_check_request_sub = _node.create_subscription<px4_msgs::msg::ArmingCheckRequest>(
     topic_namespace_prefix + "fmu/out/arming_check_request" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::ArmingCheckRequest>(),
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::ArmingCheckRequest>(),
     rclcpp::QoS(1).best_effort(),
     [this](px4_msgs::msg::ArmingCheckRequest::UniquePtr msg) {
 

--- a/px4_ros2_cpp/src/components/manual_control_input.cpp
+++ b/px4_ros2_cpp/src/components/manual_control_input.cpp
@@ -17,7 +17,8 @@ ManualControlInput::ManualControlInput(Context & context, bool is_optional)
 
   _manual_control_setpoint_sub =
     context.node().create_subscription<px4_msgs::msg::ManualControlSetpoint>(
-    context.topicNamespacePrefix() + "fmu/out/manual_control_setpoint" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ManualControlSetpoint>(), rclcpp::QoS(
+    context.topicNamespacePrefix() + "fmu/out/manual_control_setpoint" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::ManualControlSetpoint>(), rclcpp::QoS(
       1).best_effort(),
     [this](px4_msgs::msg::ManualControlSetpoint::UniquePtr msg) {
       _manual_control_setpoint = *msg;

--- a/px4_ros2_cpp/src/components/manual_control_input.cpp
+++ b/px4_ros2_cpp/src/components/manual_control_input.cpp
@@ -18,7 +18,7 @@ ManualControlInput::ManualControlInput(Context & context, bool is_optional)
   _manual_control_setpoint_sub =
     context.node().create_subscription<px4_msgs::msg::ManualControlSetpoint>(
     context.topicNamespacePrefix() + "fmu/out/manual_control_setpoint" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::ManualControlSetpoint>(), rclcpp::QoS(
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::ManualControlSetpoint>(), rclcpp::QoS(
       1).best_effort(),
     [this](px4_msgs::msg::ManualControlSetpoint::UniquePtr msg) {
       _manual_control_setpoint = *msg;

--- a/px4_ros2_cpp/src/components/message_compatibility_check.cpp
+++ b/px4_ros2_cpp/src/components/message_compatibility_check.cpp
@@ -201,7 +201,7 @@ RequestMessageFormatReturn requestMessageFormat(
           } else {
             RCLCPP_ERROR(
               node.get_logger(), "Protocol version mismatch: got %i, expected %i",
-                response.protocol_version,
+              response.protocol_version,
               px4_msgs::msg::MessageFormatRequest::LATEST_PROTOCOL_VERSION);
             request_message_format_return = RequestMessageFormatReturn::ProtocolVersionMismatch;
           }
@@ -310,7 +310,7 @@ bool messageCompatibilityCheck(
   if (!mismatched_topics.empty()) {
     RCLCPP_ERROR(
       node.get_logger(),
-        "Mismatch for the following topics, update PX4 or the px4_ros2 library and px4_msgs:%s",
+      "Mismatch for the following topics, update PX4 or the px4_ros2 library and px4_msgs:%s",
       mismatched_topics.c_str());
   }
 

--- a/px4_ros2_cpp/src/components/message_compatibility_check.cpp
+++ b/px4_ros2_cpp/src/components/message_compatibility_check.cpp
@@ -131,8 +131,10 @@ enum class RequestMessageFormatReturn
 
 RequestMessageFormatReturn requestMessageFormat(
   rclcpp::Node & node, const px4_msgs::msg::MessageFormatRequest & request,
-  const rclcpp::Subscription<px4_msgs::msg::MessageFormatResponse>::SharedPtr & message_format_response_sub,
-  const rclcpp::Publisher<px4_msgs::msg::MessageFormatRequest>::SharedPtr & message_format_request_pub,
+  const rclcpp::Subscription<px4_msgs::msg::MessageFormatResponse>::SharedPtr &
+  message_format_response_sub,
+  const rclcpp::Publisher<px4_msgs::msg::MessageFormatRequest>::SharedPtr &
+  message_format_request_pub,
   px4_msgs::msg::MessageFormatResponse & response, bool verbose)
 {
   rclcpp::WaitSet wait_set;
@@ -198,7 +200,8 @@ RequestMessageFormatReturn requestMessageFormat(
             }                                     // Else: response to a different topic, try again
           } else {
             RCLCPP_ERROR(
-              node.get_logger(), "Protocol version mismatch: got %i, expected %i", response.protocol_version,
+              node.get_logger(), "Protocol version mismatch: got %i, expected %i",
+                response.protocol_version,
               px4_msgs::msg::MessageFormatRequest::LATEST_PROTOCOL_VERSION);
             request_message_format_return = RequestMessageFormatReturn::ProtocolVersionMismatch;
           }
@@ -230,14 +233,16 @@ bool messageCompatibilityCheck(
     message_format_response_sub
     =
     node.create_subscription<px4_msgs::msg::MessageFormatResponse>(
-      topic_namespace_prefix + "fmu/out/message_format_response" + px4_ros2::getMessageNameVersion<px4_msgs::msg::MessageFormatResponse>(), rclcpp::QoS(
+      topic_namespace_prefix + "fmu/out/message_format_response" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::MessageFormatResponse>(), rclcpp::QoS(
         1).best_effort(),
       [](px4_msgs::msg::MessageFormatResponse::UniquePtr msg) {});
 
   const rclcpp::Publisher<px4_msgs::msg::MessageFormatRequest>::SharedPtr message_format_request_pub
     =
     node.create_publisher<px4_msgs::msg::MessageFormatRequest>(
-      topic_namespace_prefix + "fmu/in/message_format_request" + px4_ros2::getMessageNameVersion<px4_msgs::msg::MessageFormatRequest>(),
+      topic_namespace_prefix + "fmu/in/message_format_request" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::MessageFormatRequest>(),
       1);
 
   const std::string msgs_dir = ament_index_cpp::get_package_share_directory("px4_msgs");
@@ -304,7 +309,8 @@ bool messageCompatibilityCheck(
 
   if (!mismatched_topics.empty()) {
     RCLCPP_ERROR(
-      node.get_logger(), "Mismatch for the following topics, update PX4 or the px4_ros2 library and px4_msgs:%s",
+      node.get_logger(),
+        "Mismatch for the following topics, update PX4 or the px4_ros2 library and px4_msgs:%s",
       mismatched_topics.c_str());
   }
 

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -29,7 +29,8 @@ ModeBase::ModeBase(
     topic_namespace_prefix), _config_overrides(node, topic_namespace_prefix)
 {
   _vehicle_status_sub = node.create_subscription<px4_msgs::msg::VehicleStatus>(
-    topic_namespace_prefix + "fmu/out/vehicle_status" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
+    topic_namespace_prefix + "fmu/out/vehicle_status" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
       1).best_effort(),
     [this](px4_msgs::msg::VehicleStatus::UniquePtr msg) {
       if (_registration->registered()) {
@@ -37,10 +38,12 @@ ModeBase::ModeBase(
       }
     });
   _mode_completed_pub = node.create_publisher<px4_msgs::msg::ModeCompleted>(
-    topic_namespace_prefix + "fmu/in/mode_completed" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ModeCompleted>(),
+    topic_namespace_prefix + "fmu/in/mode_completed" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::ModeCompleted>(),
     1);
   _config_control_setpoints_pub = node.create_publisher<px4_msgs::msg::VehicleControlMode>(
-    topic_namespace_prefix + "fmu/in/config_control_setpoints" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleControlMode>(),
+    topic_namespace_prefix + "fmu/in/config_control_setpoints" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleControlMode>(),
     1);
 }
 

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -30,7 +30,7 @@ ModeBase::ModeBase(
 {
   _vehicle_status_sub = node.create_subscription<px4_msgs::msg::VehicleStatus>(
     topic_namespace_prefix + "fmu/out/vehicle_status" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
       1).best_effort(),
     [this](px4_msgs::msg::VehicleStatus::UniquePtr msg) {
       if (_registration->registered()) {
@@ -39,11 +39,11 @@ ModeBase::ModeBase(
     });
   _mode_completed_pub = node.create_publisher<px4_msgs::msg::ModeCompleted>(
     topic_namespace_prefix + "fmu/in/mode_completed" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::ModeCompleted>(),
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::ModeCompleted>(),
     1);
   _config_control_setpoints_pub = node.create_publisher<px4_msgs::msg::VehicleControlMode>(
     topic_namespace_prefix + "fmu/in/config_control_setpoints" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleControlMode>(),
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleControlMode>(),
     1);
 }
 

--- a/px4_ros2_cpp/src/components/mode_executor.cpp
+++ b/px4_ros2_cpp/src/components/mode_executor.cpp
@@ -27,7 +27,8 @@ ModeExecutorBase::ModeExecutorBase(
   _config_overrides(node, topic_namespace_prefix)
 {
   _vehicle_status_sub = _node.create_subscription<px4_msgs::msg::VehicleStatus>(
-    topic_namespace_prefix + "fmu/out/vehicle_status" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
+    topic_namespace_prefix + "fmu/out/vehicle_status" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
       1).best_effort(),
     [this](px4_msgs::msg::VehicleStatus::UniquePtr msg) {
       if (_registration->registered()) {
@@ -36,7 +37,8 @@ ModeExecutorBase::ModeExecutorBase(
     });
 
   _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
-    topic_namespace_prefix + "fmu/in/vehicle_command_mode_executor" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
+    topic_namespace_prefix + "fmu/in/vehicle_command_mode_executor" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
     1);
 
 }
@@ -130,7 +132,8 @@ Result ModeExecutorBase::sendCommandSync(
   // (We could also use exchange_in_use_by_wait_set_state(), but that might cause an
   // inconsistent state)
   const auto vehicle_command_ack_sub = _node.create_subscription<px4_msgs::msg::VehicleCommandAck>(
-    _topic_namespace_prefix + "fmu/out/vehicle_command_ack" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommandAck>(), rclcpp::QoS(
+    _topic_namespace_prefix + "fmu/out/vehicle_command_ack" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommandAck>(), rclcpp::QoS(
       1).best_effort(),
     [](px4_msgs::msg::VehicleCommandAck::UniquePtr msg) {});
 
@@ -290,7 +293,7 @@ void ModeExecutorBase::arm(const CompletedCallback & on_completed)
     [this](const px4_msgs::msg::VehicleStatus::UniquePtr & msg) {return _is_armed;}, on_completed);
 }
 
-void ModeExecutorBase::disarm(const CompletedCallback & on_completed, const bool & forced)
+void ModeExecutorBase::disarm(const CompletedCallback & on_completed, bool forced)
 {
   if (!_is_armed) {
     on_completed(Result::Success);
@@ -298,7 +301,8 @@ void ModeExecutorBase::disarm(const CompletedCallback & on_completed, const bool
   }
 
   const float param2 = forced ? 21196.f : NAN;
-  const Result result = sendCommandSync(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_COMPONENT_ARM_DISARM,
+  const Result result =
+    sendCommandSync(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_COMPONENT_ARM_DISARM,
     0.f, param2);
 
 
@@ -456,7 +460,8 @@ ModeExecutorBase::ScheduledMode::ScheduledMode(
   const std::string & topic_namespace_prefix)
 {
   _mode_completed_sub = node.create_subscription<px4_msgs::msg::ModeCompleted>(
-    topic_namespace_prefix + "fmu/out/mode_completed" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ModeCompleted>(), rclcpp::QoS(
+    topic_namespace_prefix + "fmu/out/mode_completed" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::ModeCompleted>(), rclcpp::QoS(
       1).best_effort(),
     [this, &node](px4_msgs::msg::ModeCompleted::UniquePtr msg) {
       if (active() && msg->nav_state == static_cast<uint8_t>(_mode_id)) {

--- a/px4_ros2_cpp/src/components/mode_executor.cpp
+++ b/px4_ros2_cpp/src/components/mode_executor.cpp
@@ -297,18 +297,10 @@ void ModeExecutorBase::disarm(const CompletedCallback & on_completed, const bool
     return;
   }
 
-  Result result;
+  const float param2 = forced ? 21196.f : NAN;
+  const Result result = sendCommandSync(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_COMPONENT_ARM_DISARM,
+    0.f, param2);
 
-  if (forced)
-  {
-    result = sendCommandSync(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_COMPONENT_ARM_DISARM,
-    0.f, 21196.f);
-  }
-  else
-  {
-    result = sendCommandSync(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_COMPONENT_ARM_DISARM,
-    0.f);
-  }
 
   if (result != Result::Success) {
     on_completed(result);

--- a/px4_ros2_cpp/src/components/mode_executor.cpp
+++ b/px4_ros2_cpp/src/components/mode_executor.cpp
@@ -28,7 +28,7 @@ ModeExecutorBase::ModeExecutorBase(
 {
   _vehicle_status_sub = _node.create_subscription<px4_msgs::msg::VehicleStatus>(
     topic_namespace_prefix + "fmu/out/vehicle_status" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
       1).best_effort(),
     [this](px4_msgs::msg::VehicleStatus::UniquePtr msg) {
       if (_registration->registered()) {
@@ -38,7 +38,7 @@ ModeExecutorBase::ModeExecutorBase(
 
   _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
     topic_namespace_prefix + "fmu/in/vehicle_command_mode_executor" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
     1);
 
 }
@@ -133,7 +133,7 @@ Result ModeExecutorBase::sendCommandSync(
   // inconsistent state)
   const auto vehicle_command_ack_sub = _node.create_subscription<px4_msgs::msg::VehicleCommandAck>(
     _topic_namespace_prefix + "fmu/out/vehicle_command_ack" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommandAck>(), rclcpp::QoS(
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommandAck>(), rclcpp::QoS(
       1).best_effort(),
     [](px4_msgs::msg::VehicleCommandAck::UniquePtr msg) {});
 
@@ -302,7 +302,8 @@ void ModeExecutorBase::disarm(const CompletedCallback & on_completed, bool force
 
   const float param2 = forced ? 21196.f : NAN;
   const Result result =
-    sendCommandSync(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_COMPONENT_ARM_DISARM,
+    sendCommandSync(
+    px4_msgs::msg::VehicleCommand::VEHICLE_CMD_COMPONENT_ARM_DISARM,
     0.f, param2);
 
 
@@ -461,7 +462,7 @@ ModeExecutorBase::ScheduledMode::ScheduledMode(
 {
   _mode_completed_sub = node.create_subscription<px4_msgs::msg::ModeCompleted>(
     topic_namespace_prefix + "fmu/out/mode_completed" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::ModeCompleted>(), rclcpp::QoS(
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::ModeCompleted>(), rclcpp::QoS(
       1).best_effort(),
     [this, &node](px4_msgs::msg::ModeCompleted::UniquePtr msg) {
       if (active() && msg->nav_state == static_cast<uint8_t>(_mode_id)) {

--- a/px4_ros2_cpp/src/components/overrides.cpp
+++ b/px4_ros2_cpp/src/components/overrides.cpp
@@ -16,7 +16,7 @@ ConfigOverrides::ConfigOverrides(rclcpp::Node & node, const std::string & topic_
 {
   _config_overrides_pub = _node.create_publisher<px4_msgs::msg::ConfigOverrides>(
     topic_namespace_prefix + "fmu/in/config_overrides_request" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::ConfigOverrides>(),
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::ConfigOverrides>(),
     1);
 }
 

--- a/px4_ros2_cpp/src/components/overrides.cpp
+++ b/px4_ros2_cpp/src/components/overrides.cpp
@@ -15,7 +15,8 @@ ConfigOverrides::ConfigOverrides(rclcpp::Node & node, const std::string & topic_
 : _node(node)
 {
   _config_overrides_pub = _node.create_publisher<px4_msgs::msg::ConfigOverrides>(
-    topic_namespace_prefix + "fmu/in/config_overrides_request" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ConfigOverrides>(),
+    topic_namespace_prefix + "fmu/in/config_overrides_request" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::ConfigOverrides>(),
     1);
 }
 

--- a/px4_ros2_cpp/src/components/registration.cpp
+++ b/px4_ros2_cpp/src/components/registration.cpp
@@ -19,18 +19,21 @@ Registration::Registration(rclcpp::Node & node, const std::string & topic_namesp
 {
   _register_ext_component_reply_sub =
     node.create_subscription<px4_msgs::msg::RegisterExtComponentReply>(
-    topic_namespace_prefix + "fmu/out/register_ext_component_reply" + px4_ros2::getMessageNameVersion<px4_msgs::msg::RegisterExtComponentReply>(),
+    topic_namespace_prefix + "fmu/out/register_ext_component_reply" +
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::RegisterExtComponentReply>(),
     rclcpp::QoS(1).best_effort(),
     [](px4_msgs::msg::RegisterExtComponentReply::UniquePtr msg) {
     });
 
   _register_ext_component_request_pub =
     node.create_publisher<px4_msgs::msg::RegisterExtComponentRequest>(
-    topic_namespace_prefix + "fmu/in/register_ext_component_request" + px4_ros2::getMessageNameVersion<px4_msgs::msg::RegisterExtComponentRequest>(),
+    topic_namespace_prefix + "fmu/in/register_ext_component_request" +
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::RegisterExtComponentRequest>(),
     1);
 
   _unregister_ext_component_pub = node.create_publisher<px4_msgs::msg::UnregisterExtComponent>(
-    topic_namespace_prefix + "fmu/in/unregister_ext_component" + px4_ros2::getMessageNameVersion<px4_msgs::msg::UnregisterExtComponent>(),
+    topic_namespace_prefix + "fmu/in/unregister_ext_component" +
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::UnregisterExtComponent>(),
     1);
 
   _unregister_ext_component.mode_id = px4_ros2::ModeBase::kModeIDInvalid;

--- a/px4_ros2_cpp/src/components/wait_for_fmu.cpp
+++ b/px4_ros2_cpp/src/components/wait_for_fmu.cpp
@@ -17,7 +17,8 @@ bool waitForFMU(
   RCLCPP_DEBUG(node.get_logger(), "Waiting for FMU...");
   const rclcpp::Subscription<px4_msgs::msg::VehicleStatus>::SharedPtr vehicle_status_sub =
     node.create_subscription<px4_msgs::msg::VehicleStatus>(
-    topic_namespace_prefix + "fmu/out/vehicle_status" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
+    topic_namespace_prefix + "fmu/out/vehicle_status" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
       1).best_effort(),
     [](px4_msgs::msg::VehicleStatus::UniquePtr msg) {});
 

--- a/px4_ros2_cpp/src/components/wait_for_fmu.cpp
+++ b/px4_ros2_cpp/src/components/wait_for_fmu.cpp
@@ -18,7 +18,7 @@ bool waitForFMU(
   const rclcpp::Subscription<px4_msgs::msg::VehicleStatus>::SharedPtr vehicle_status_sub =
     node.create_subscription<px4_msgs::msg::VehicleStatus>(
     topic_namespace_prefix + "fmu/out/vehicle_status" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
       1).best_effort(),
     [](px4_msgs::msg::VehicleStatus::UniquePtr msg) {});
 

--- a/px4_ros2_cpp/src/control/peripheral_actuators.cpp
+++ b/px4_ros2_cpp/src/control/peripheral_actuators.cpp
@@ -16,7 +16,7 @@ PeripheralActuatorControls::PeripheralActuatorControls(Context & context)
 {
   _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
     context.topicNamespacePrefix() + "fmu/in/vehicle_command" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
     1);
   _last_update = _node.get_clock()->now();
 }

--- a/px4_ros2_cpp/src/control/peripheral_actuators.cpp
+++ b/px4_ros2_cpp/src/control/peripheral_actuators.cpp
@@ -15,7 +15,8 @@ PeripheralActuatorControls::PeripheralActuatorControls(Context & context)
 : _node(context.node())
 {
   _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
-    context.topicNamespacePrefix() + "fmu/in/vehicle_command" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
+    context.topicNamespacePrefix() + "fmu/in/vehicle_command" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
     1);
   _last_update = _node.get_clock()->now();
 }

--- a/px4_ros2_cpp/src/control/setpoint_types/direct_actuators.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/direct_actuators.cpp
@@ -15,11 +15,11 @@ DirectActuatorsSetpointType::DirectActuatorsSetpointType(Context & context)
 {
   _actuator_motors_pub = context.node().create_publisher<px4_msgs::msg::ActuatorMotors>(
     context.topicNamespacePrefix() + "fmu/in/actuator_motors" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::ActuatorMotors>(),
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::ActuatorMotors>(),
     1);
   _actuator_servos_pub = context.node().create_publisher<px4_msgs::msg::ActuatorServos>(
     context.topicNamespacePrefix() + "fmu/in/actuator_servos" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::ActuatorServos>(),
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::ActuatorServos>(),
     1);
 }
 

--- a/px4_ros2_cpp/src/control/setpoint_types/direct_actuators.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/direct_actuators.cpp
@@ -14,10 +14,12 @@ DirectActuatorsSetpointType::DirectActuatorsSetpointType(Context & context)
 : SetpointBase(context), _node(context.node())
 {
   _actuator_motors_pub = context.node().create_publisher<px4_msgs::msg::ActuatorMotors>(
-    context.topicNamespacePrefix() + "fmu/in/actuator_motors" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ActuatorMotors>(),
+    context.topicNamespacePrefix() + "fmu/in/actuator_motors" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::ActuatorMotors>(),
     1);
   _actuator_servos_pub = context.node().create_publisher<px4_msgs::msg::ActuatorServos>(
-    context.topicNamespacePrefix() + "fmu/in/actuator_servos" + px4_ros2::getMessageNameVersion<px4_msgs::msg::ActuatorServos>(),
+    context.topicNamespacePrefix() + "fmu/in/actuator_servos" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::ActuatorServos>(),
     1);
 }
 

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/attitude.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/attitude.cpp
@@ -16,7 +16,7 @@ AttitudeSetpointType::AttitudeSetpointType(Context & context)
   _vehicle_attitude_setpoint_pub =
     context.node().create_publisher<px4_msgs::msg::VehicleAttitudeSetpoint>(
     context.topicNamespacePrefix() + "fmu/in/vehicle_attitude_setpoint" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleAttitudeSetpoint>(),
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleAttitudeSetpoint>(),
     1);
 }
 

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/attitude.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/attitude.cpp
@@ -15,7 +15,8 @@ AttitudeSetpointType::AttitudeSetpointType(Context & context)
 {
   _vehicle_attitude_setpoint_pub =
     context.node().create_publisher<px4_msgs::msg::VehicleAttitudeSetpoint>(
-    context.topicNamespacePrefix() + "fmu/in/vehicle_attitude_setpoint" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleAttitudeSetpoint>(),
+    context.topicNamespacePrefix() + "fmu/in/vehicle_attitude_setpoint" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleAttitudeSetpoint>(),
     1);
 }
 

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/rates.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/rates.cpp
@@ -14,7 +14,8 @@ RatesSetpointType::RatesSetpointType(Context & context)
 {
   _vehicle_rates_setpoint_pub =
     context.node().create_publisher<px4_msgs::msg::VehicleRatesSetpoint>(
-    context.topicNamespacePrefix() + "fmu/in/vehicle_rates_setpoint" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleRatesSetpoint>(),
+    context.topicNamespacePrefix() + "fmu/in/vehicle_rates_setpoint" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleRatesSetpoint>(),
     1);
 }
 

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/rates.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/rates.cpp
@@ -15,7 +15,7 @@ RatesSetpointType::RatesSetpointType(Context & context)
   _vehicle_rates_setpoint_pub =
     context.node().create_publisher<px4_msgs::msg::VehicleRatesSetpoint>(
     context.topicNamespacePrefix() + "fmu/in/vehicle_rates_setpoint" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleRatesSetpoint>(),
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleRatesSetpoint>(),
     1);
 }
 

--- a/px4_ros2_cpp/src/control/setpoint_types/goto.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/goto.cpp
@@ -15,7 +15,8 @@ GotoSetpointType::GotoSetpointType(Context & context)
 {
   _goto_setpoint_pub =
     context.node().create_publisher<px4_msgs::msg::GotoSetpoint>(
-    context.topicNamespacePrefix() + "fmu/in/goto_setpoint" + px4_ros2::getMessageNameVersion<px4_msgs::msg::GotoSetpoint>(),
+    context.topicNamespacePrefix() + "fmu/in/goto_setpoint" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::GotoSetpoint>(),
     1);
 }
 

--- a/px4_ros2_cpp/src/control/setpoint_types/goto.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/goto.cpp
@@ -16,7 +16,7 @@ GotoSetpointType::GotoSetpointType(Context & context)
   _goto_setpoint_pub =
     context.node().create_publisher<px4_msgs::msg::GotoSetpoint>(
     context.topicNamespacePrefix() + "fmu/in/goto_setpoint" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::GotoSetpoint>(),
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::GotoSetpoint>(),
     1);
 }
 

--- a/px4_ros2_cpp/src/navigation/experimental/global_position_measurement_interface.cpp
+++ b/px4_ros2_cpp/src/navigation/experimental/global_position_measurement_interface.cpp
@@ -17,7 +17,8 @@ GlobalPositionMeasurementInterface::GlobalPositionMeasurementInterface(rclcpp::N
 {
   _aux_global_position_pub =
     node.create_publisher<VehicleGlobalPosition>(
-    topicNamespacePrefix() + "fmu/in/aux_global_position" + px4_ros2::getMessageNameVersion<VehicleGlobalPosition>(),
+    topicNamespacePrefix() + "fmu/in/aux_global_position" +
+      px4_ros2::getMessageNameVersion<VehicleGlobalPosition>(),
     10);
 }
 

--- a/px4_ros2_cpp/src/navigation/experimental/global_position_measurement_interface.cpp
+++ b/px4_ros2_cpp/src/navigation/experimental/global_position_measurement_interface.cpp
@@ -18,7 +18,7 @@ GlobalPositionMeasurementInterface::GlobalPositionMeasurementInterface(rclcpp::N
   _aux_global_position_pub =
     node.create_publisher<VehicleGlobalPosition>(
     topicNamespacePrefix() + "fmu/in/aux_global_position" +
-      px4_ros2::getMessageNameVersion<VehicleGlobalPosition>(),
+    px4_ros2::getMessageNameVersion<VehicleGlobalPosition>(),
     10);
 }
 

--- a/px4_ros2_cpp/src/navigation/experimental/local_position_measurement_interface.cpp
+++ b/px4_ros2_cpp/src/navigation/experimental/local_position_measurement_interface.cpp
@@ -20,7 +20,8 @@ LocalPositionMeasurementInterface::LocalPositionMeasurementInterface(
   _velocity_frame(velocityFrameToMessageFrame(velocity_frame))
 {
   _aux_local_position_pub = node.create_publisher<AuxLocalPosition>(
-    topicNamespacePrefix() + "fmu/in/vehicle_visual_odometry" + px4_ros2::getMessageNameVersion<AuxLocalPosition>(),
+    topicNamespacePrefix() + "fmu/in/vehicle_visual_odometry" +
+      px4_ros2::getMessageNameVersion<AuxLocalPosition>(),
     10);
 }
 

--- a/px4_ros2_cpp/src/navigation/experimental/local_position_measurement_interface.cpp
+++ b/px4_ros2_cpp/src/navigation/experimental/local_position_measurement_interface.cpp
@@ -21,7 +21,7 @@ LocalPositionMeasurementInterface::LocalPositionMeasurementInterface(
 {
   _aux_local_position_pub = node.create_publisher<AuxLocalPosition>(
     topicNamespacePrefix() + "fmu/in/vehicle_visual_odometry" +
-      px4_ros2::getMessageNameVersion<AuxLocalPosition>(),
+    px4_ros2::getMessageNameVersion<AuxLocalPosition>(),
     10);
 }
 

--- a/px4_ros2_cpp/src/utils/geodesic.cpp
+++ b/px4_ros2_cpp/src/utils/geodesic.cpp
@@ -16,7 +16,8 @@ MapProjection::MapProjection(Context & context)
 {
   _map_projection_math = std::make_unique<MapProjectionImpl>();
   _vehicle_local_position_sub = _node.create_subscription<px4_msgs::msg::VehicleLocalPosition>(
-    "fmu/out/vehicle_local_position" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleLocalPosition>(), rclcpp::QoS(
+    "fmu/out/vehicle_local_position" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleLocalPosition>(), rclcpp::QoS(
       1).best_effort(),
     [this](px4_msgs::msg::VehicleLocalPosition::UniquePtr msg) {
       vehicleLocalPositionCallback(std::move(msg));

--- a/px4_ros2_cpp/src/utils/geodesic.cpp
+++ b/px4_ros2_cpp/src/utils/geodesic.cpp
@@ -17,7 +17,7 @@ MapProjection::MapProjection(Context & context)
   _map_projection_math = std::make_unique<MapProjectionImpl>();
   _vehicle_local_position_sub = _node.create_subscription<px4_msgs::msg::VehicleLocalPosition>(
     "fmu/out/vehicle_local_position" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleLocalPosition>(), rclcpp::QoS(
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleLocalPosition>(), rclcpp::QoS(
       1).best_effort(),
     [this](px4_msgs::msg::VehicleLocalPosition::UniquePtr msg) {
       vehicleLocalPositionCallback(std::move(msg));

--- a/px4_ros2_cpp/test/integration/global_navigation.cpp
+++ b/px4_ros2_cpp/test/integration/global_navigation.cpp
@@ -40,7 +40,8 @@ protected:
 
     // Subscribe to PX4 EKF estimator status flags
     _subscriber = _node->create_subscription<EstimatorStatusFlags>(
-      "fmu/out/estimator_status_flags" + px4_ros2::getMessageNameVersion<EstimatorStatusFlags>(), rclcpp::QoS(
+      "fmu/out/estimator_status_flags" + px4_ros2::getMessageNameVersion<EstimatorStatusFlags>(),
+      rclcpp::QoS(
         10).best_effort(),
       [this](EstimatorStatusFlags::UniquePtr msg) {
         _estimator_status_flags = std::move(msg);

--- a/px4_ros2_cpp/test/integration/local_navigation.cpp
+++ b/px4_ros2_cpp/test/integration/local_navigation.cpp
@@ -41,7 +41,8 @@ protected:
 
     // Subscribe to PX4 EKF estimator status flags
     _subscriber = _node->create_subscription<EstimatorStatusFlags>(
-      "fmu/out/estimator_status_flags" + px4_ros2::getMessageNameVersion<EstimatorStatusFlags>(), rclcpp::QoS(
+      "fmu/out/estimator_status_flags" + px4_ros2::getMessageNameVersion<EstimatorStatusFlags>(),
+      rclcpp::QoS(
         10).best_effort(),
       [this](EstimatorStatusFlags::UniquePtr msg) {
         _estimator_status_flags = std::move(msg);

--- a/px4_ros2_cpp/test/integration/mode_executor.cpp
+++ b/px4_ros2_cpp/test/integration/mode_executor.cpp
@@ -81,7 +81,8 @@ class ModeExecutorTest : public px4_ros2::ModeExecutorBase
 public:
   ModeExecutorTest(rclcpp::Node & node, FlightModeTest & owned_mode, bool activate_immediately)
   : ModeExecutorBase(node,
-      ModeExecutorBase::Settings{activate_immediately ? Settings::Activation::ActivateImmediately : Settings::Activation::ActivateOnlyWhenArmed},
+      ModeExecutorBase::Settings{activate_immediately ? Settings::Activation::ActivateImmediately :
+        Settings::Activation::ActivateOnlyWhenArmed},
       owned_mode),
     _node(node)
   {}

--- a/px4_ros2_cpp/test/integration/overrides.cpp
+++ b/px4_ros2_cpp/test/integration/overrides.cpp
@@ -80,7 +80,8 @@ class ModeExecutorTest : public px4_ros2::ModeExecutorBase
 public:
   ModeExecutorTest(rclcpp::Node & node, FlightModeTest & owned_mode, bool activate_immediately)
   : ModeExecutorBase(node,
-      ModeExecutorBase::Settings{activate_immediately ? Settings::Activation::ActivateImmediately : Settings::Activation::ActivateOnlyWhenArmed},
+      ModeExecutorBase::Settings{activate_immediately ? Settings::Activation::ActivateImmediately :
+        Settings::Activation::ActivateOnlyWhenArmed},
       owned_mode),
     _node(node)
   {}

--- a/px4_ros2_cpp/test/integration/util.cpp
+++ b/px4_ros2_cpp/test/integration/util.cpp
@@ -85,7 +85,8 @@ void VehicleState::setGPSFailure(bool failure)
   sendCommand(
     px4_msgs::msg::VehicleCommand::VEHICLE_CMD_INJECT_FAILURE,
     px4_msgs::msg::VehicleCommand::FAILURE_UNIT_SENSOR_GPS,
-    failure ? px4_msgs::msg::VehicleCommand::FAILURE_TYPE_OFF : px4_msgs::msg::VehicleCommand::FAILURE_TYPE_OK,
+    failure ? px4_msgs::msg::VehicleCommand::FAILURE_TYPE_OFF :
+    px4_msgs::msg::VehicleCommand::FAILURE_TYPE_OK,
     0);
 }
 
@@ -94,6 +95,7 @@ void VehicleState::setForceLowBattery(bool enabled)
   sendCommand(
     px4_msgs::msg::VehicleCommand::VEHICLE_CMD_INJECT_FAILURE,
     px4_msgs::msg::VehicleCommand::FAILURE_UNIT_SYSTEM_BATTERY,
-    enabled ? px4_msgs::msg::VehicleCommand::FAILURE_TYPE_OFF : px4_msgs::msg::VehicleCommand::FAILURE_TYPE_OK,
+    enabled ? px4_msgs::msg::VehicleCommand::FAILURE_TYPE_OFF :
+    px4_msgs::msg::VehicleCommand::FAILURE_TYPE_OK,
     0);
 }

--- a/px4_ros2_cpp/test/unit/global_navigation.cpp
+++ b/px4_ros2_cpp/test/unit/global_navigation.cpp
@@ -42,7 +42,8 @@ protected:
       *_node);
     _subscriber =
       _node->create_subscription<px4_msgs::msg::VehicleGlobalPosition>(
-      "/fmu/in/aux_global_position" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleGlobalPosition>(), rclcpp::QoS(
+      "/fmu/in/aux_global_position" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleGlobalPosition>(), rclcpp::QoS(
         10).best_effort(),
       [this](px4_msgs::msg::VehicleGlobalPosition::UniquePtr msg) {
         _update_msg = std::move(msg);


### PR DESCRIPTION
This PR introduces the disarm function to the mode executor. it is also possible to force the disarm. This is highly linked to this [PR](https://github.com/Auterion/px4-ros2-interface-lib/pull/99) and the use case is the same