### PR TITLE
build: pin auterion px4 messages version during releases

### DIFF
--- a/px4_ros2_cpp/rosdep-foxy.yaml
+++ b/px4_ros2_cpp/rosdep-foxy.yaml
@@ -1,3 +1,3 @@
 px4_msgs:
   ubuntu:
-    - ros-foxy-px4-msgs
+    - ros-foxy-px4-msgs=3.2.1-0focal

--- a/px4_ros2_cpp/rosdep-humble.yaml
+++ b/px4_ros2_cpp/rosdep-humble.yaml
@@ -1,3 +1,3 @@
 px4_msgs:
   ubuntu:
-    - ros-humble-px4-msgs
+    - ros-humble-px4-msgs=3.2.1-0jammy

--- a/px4_ros2_cpp/rosdep-rolling.yaml
+++ b/px4_ros2_cpp/rosdep-rolling.yaml
@@ -1,3 +1,3 @@
 px4_msgs:
   ubuntu:
-    - ros-rolling-px4-msgs
+    - ros-rolling-px4-msgs=3.2.1-0noble


### PR DESCRIPTION
For release workflows which use rosdep to install dependencies, pin the version of the Auterion PX4 messages package.