### PR TITLE
[against another PR] VTOL Transition acceleration setpoint computation 

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/control/vtol.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/vtol.hpp
@@ -8,6 +8,7 @@
  #include <px4_msgs/msg/vehicle_command.hpp>
  #include <px4_msgs/msg/vehicle_status.hpp>
  #include <px4_msgs/msg/vtol_vehicle_status.hpp>
+ #include <px4_msgs/msg/vehicle_local_position.hpp>
  #include <Eigen/Core>
 
  #include <px4_ros2/common/setpoint_base.hpp>
@@ -42,7 +43,7 @@ public:
   void to_multicopter();
   void to_fixedwing();
 
-  Eigen::Vector3f get_acceleration_setpoint_during_transition();
+  Eigen::Vector3f compute_acceleration_setpoint_during_transition();
 
   VTOL::State get_current_state();
 
@@ -51,20 +52,20 @@ private:
   rclcpp::Publisher<px4_msgs::msg::VehicleCommand>::SharedPtr _vehicle_command_pub;
   rclcpp::Subscription<px4_msgs::msg::VehicleStatus>::SharedPtr _vehicle_status_sub;
   rclcpp::Subscription<px4_msgs::msg::VtolVehicleStatus>::SharedPtr _vtol_vehicle_status_sub;
+  rclcpp::Subscription<px4_msgs::msg::VehicleLocalPosition>::SharedPtr _vehicle_local_position_sub;
   rclcpp::Time _last_command_sent;
   rclcpp::Time _last_vtol_vehicle_status_received;
 
   px4_msgs::msg::VehicleStatus::UniquePtr _vehicle_status_msg;
   px4_msgs::msg::VtolVehicleStatus::UniquePtr _vtol_vehicle_status_msg;
+  px4_msgs::msg::VehicleLocalPosition::UniquePtr _vehicle_local_position_msg;
 
   uint _system_id;
   uint _component_id;
 
-  bool _is_backtransition;
+  Eigen::Vector2f _vehicle_velocity_xy{NAN, NAN};
 
   VTOL::State _current_state{VTOL::State::UNDEFINED};
-
-  float get_pitch_setpoint_during_transition();
 };
 
 /** @}*/

--- a/px4_ros2_cpp/include/px4_ros2/control/vtol.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/vtol.hpp
@@ -42,6 +42,8 @@ public:
   void to_multicopter();
   void to_fixedwing();
 
+  Eigen::Vector3f get_acceleration_setpoint_during_transition();
+
   VTOL::State get_current_state();
 
 private:
@@ -58,7 +60,11 @@ private:
   uint _system_id;
   uint _component_id;
 
+  bool _is_backtransition;
+
   VTOL::State _current_state{VTOL::State::UNDEFINED};
+
+  float get_pitch_setpoint_during_transition();
 };
 
 /** @}*/

--- a/px4_ros2_cpp/include/px4_ros2/control/vtol.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/vtol.hpp
@@ -55,6 +55,8 @@ private:
   rclcpp::Subscription<px4_msgs::msg::VehicleLocalPosition>::SharedPtr _vehicle_local_position_sub;
   rclcpp::Time _last_command_sent;
   rclcpp::Time _last_vtol_vehicle_status_received;
+  rclcpp::Time _last_pitch_integrator_update{0, 0, _node.get_clock()->get_clock_type()};
+
 
   px4_msgs::msg::VehicleStatus::UniquePtr _vehicle_status_msg;
   px4_msgs::msg::VtolVehicleStatus::UniquePtr _vtol_vehicle_status_msg;
@@ -63,9 +65,27 @@ private:
   uint _system_id;
   uint _component_id;
 
+  float _vehicle_heading{0.f}; 
+  float _decel_error_bt_int{0.f}; 
+
+  Eigen::Vector2f _vehicle_position_xy{NAN, NAN}; 
   Eigen::Vector2f _vehicle_velocity_xy{NAN, NAN};
+  Eigen::Vector2f _vehicle_acceleration_xy{NAN, NAN}; 
+
+  Eigen::Vector2f _backtransition_commanded_position{NAN, NAN}; 
+  
+  bool _vehicle_velocity_xy_valid{false}; 
+  bool _vehicle_position_xy_valid{false}; 
 
   VTOL::State _current_state{VTOL::State::UNDEFINED};
+
+  float compute_pitch_setpoint_during_backtransition();
+
+  static constexpr float VT_B_DEC_MSS = 2.f; 
+  static constexpr float VT_B_DEC_I = 0.1f; 
+  static constexpr float DECELERATION_INTEGRATOR_LIMIT = 0.3f;
+  static constexpr float BACK_TRANS_END_DIST = 50.f; 
+
 };
 
 /** @}*/

--- a/px4_ros2_cpp/src/control/vtol.cpp
+++ b/px4_ros2_cpp/src/control/vtol.cpp
@@ -67,6 +67,8 @@ void VTOL::to_multicopter()
 {
   const auto now = _node.get_clock()->now();
 
+  _is_backtransition = true;
+
   if (now - _last_vtol_vehicle_status_received < 2s) {
     if ((_current_state == VTOL::State::FIXED_WING ||
       _current_state == VTOL::State::TRANSITION_TO_FIXED_WING) &&
@@ -95,6 +97,8 @@ void VTOL::to_fixedwing()
 {
   const auto now = _node.get_clock()->now();
 
+  _is_backtransition = false;
+
   if (now - _last_vtol_vehicle_status_received < 2s) {
     if ((_current_state == VTOL::State::MULTICOPTER ||
       _current_state == VTOL::State::TRANSITION_TO_MULTICOPTER) &&
@@ -118,5 +122,23 @@ void VTOL::to_fixedwing()
     RCLCPP_WARN(_node.get_logger(), "Current VTOL vehicle state unknown. Not able to transition.");
   }
 }
+
+Eigen::Vector3f VTOL::get_acceleration_setpoint_during_transition()
+{
+  // float pitch_setpoint = _is_backtransition ? VTOL::get_pitch_setpoint_during_transition() : 0.f;
+
+  Eigen::Vector3f acceleration_setpoint_during_transition{0.f, 0.f, NAN};
+
+  return acceleration_setpoint_during_transition;
+
+}
+
+float VTOL::get_pitch_setpoint_during_transition()
+{
+
+  return 0.f;
+}
+
+
 }
 // namespace px4_ros2


### PR DESCRIPTION
Add function to compute acceleration setpoint during a vtol transition.   `TrajectorySetpoint.msg` sets: 
- `acceleration = {0.f, 0.f, NAN}` during front transition and decelerates during back transition 
