### PR TITLE
Remove deprecated ament_target_dependencies

### DIFF
--- a/examples/cpp/modes/executor_with_multiple_modes/CMakeLists.txt
+++ b/examples/cpp/modes/executor_with_multiple_modes/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(px4_ros2_cpp REQUIRED)
 include_directories(include ${Eigen3_INCLUDE_DIRS})
 add_executable(example_executor_with_multiple_modes
         src/main.cpp)
-ament_target_dependencies(example_executor_with_multiple_modes Eigen3 px4_ros2_cpp rclcpp)
+target_link_libraries(example_executor_with_multiple_modes PUBLIC Eigen3::Eigen px4_ros2_cpp::px4_ros2_cpp rclcpp::rclcpp)
 
 install(TARGETS
         example_executor_with_multiple_modes

--- a/examples/cpp/modes/fw_attitude/CMakeLists.txt
+++ b/examples/cpp/modes/fw_attitude/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(px4_ros2_cpp REQUIRED)
 include_directories(include ${Eigen3_INCLUDE_DIRS})
 add_executable(example_mode_fw_attitude
         src/main.cpp)
-ament_target_dependencies(example_mode_fw_attitude px4_ros2_cpp rclcpp)
+target_link_libraries(example_mode_fw_attitude PUBLIC px4_ros2_cpp::px4_ros2_cpp rclcpp::rclcpp)
 
 install(TARGETS
         example_mode_fw_attitude

--- a/examples/cpp/modes/goto/CMakeLists.txt
+++ b/examples/cpp/modes/goto/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(px4_ros2_cpp REQUIRED)
 include_directories(include ${Eigen3_INCLUDE_DIRS})
 add_executable(example_mode_goto
         src/main.cpp)
-ament_target_dependencies(example_mode_goto Eigen3 px4_ros2_cpp rclcpp)
+target_link_libraries(example_mode_goto PUBLIC Eigen3::Eigen px4_ros2_cpp::px4_ros2_cpp rclcpp::rclcpp)
 
 install(TARGETS
         example_mode_goto

--- a/examples/cpp/modes/goto_global/CMakeLists.txt
+++ b/examples/cpp/modes/goto_global/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(px4_ros2_cpp REQUIRED)
 include_directories(include ${Eigen3_INCLUDE_DIRS})
 add_executable(example_mode_goto_global
         src/main.cpp)
-ament_target_dependencies(example_mode_goto_global Eigen3 px4_ros2_cpp rclcpp)
+target_link_libraries(example_mode_goto_global PUBLIC Eigen3::Eigen px4_ros2_cpp::px4_ros2_cpp rclcpp::rclcpp)
 
 install(TARGETS
         example_mode_goto_global

--- a/examples/cpp/modes/manual/CMakeLists.txt
+++ b/examples/cpp/modes/manual/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(px4_ros2_cpp REQUIRED)
 include_directories(include ${Eigen3_INCLUDE_DIRS})
 add_executable(example_mode_manual
         src/main.cpp)
-ament_target_dependencies(example_mode_manual Eigen3 px4_ros2_cpp rclcpp)
+target_link_libraries(example_mode_manual PUBLIC Eigen3::Eigen px4_ros2_cpp::px4_ros2_cpp rclcpp::rclcpp)
 
 install(TARGETS
         example_mode_manual

--- a/examples/cpp/modes/mode_with_executor/CMakeLists.txt
+++ b/examples/cpp/modes/mode_with_executor/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(px4_ros2_cpp REQUIRED)
 include_directories(include ${Eigen3_INCLUDE_DIRS})
 add_executable(example_mode_with_executor
         src/main.cpp)
-ament_target_dependencies(example_mode_with_executor Eigen3 px4_ros2_cpp rclcpp)
+target_link_libraries(example_mode_with_executor PUBLIC Eigen3::Eigen px4_ros2_cpp::px4_ros2_cpp rclcpp::rclcpp)
 
 install(TARGETS
         example_mode_with_executor

--- a/examples/cpp/modes/rtl_replacement/CMakeLists.txt
+++ b/examples/cpp/modes/rtl_replacement/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(px4_ros2_cpp REQUIRED)
 include_directories(include ${Eigen3_INCLUDE_DIRS})
 add_executable(example_mode_rtl
         src/main.cpp)
-ament_target_dependencies(example_mode_rtl Eigen3 px4_ros2_cpp rclcpp)
+target_link_libraries(example_mode_rtl PUBLIC Eigen3::Eigen px4_ros2_cpp::px4_ros2_cpp rclcpp::rclcpp)
 
 install(TARGETS
         example_mode_rtl

--- a/examples/cpp/navigation/global_navigation/CMakeLists.txt
+++ b/examples/cpp/navigation/global_navigation/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(px4_ros2_cpp REQUIRED)
 include_directories(include ${Eigen3_INCLUDE_DIRS})
 add_executable(example_global_navigation
         src/main.cpp)
-ament_target_dependencies(example_global_navigation Eigen3 px4_ros2_cpp rclcpp)
+target_link_libraries(example_global_navigation PUBLIC Eigen3::Eigen px4_ros2_cpp::px4_ros2_cpp rclcpp::rclcpp)
 
 install(TARGETS
         example_global_navigation

--- a/examples/cpp/navigation/local_navigation/CMakeLists.txt
+++ b/examples/cpp/navigation/local_navigation/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(px4_ros2_cpp REQUIRED)
 include_directories(include ${Eigen3_INCLUDE_DIRS})
 add_executable(example_local_navigation
         src/main.cpp)
-ament_target_dependencies(example_local_navigation Eigen3 px4_ros2_cpp rclcpp)
+target_link_libraries(example_local_navigation PUBLIC Eigen3::Eigen px4_ros2_cpp::px4_ros2_cpp rclcpp::rclcpp)
 
 install(TARGETS
         example_local_navigation

--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -84,7 +84,7 @@ add_library(px4_ros2_cpp
         src/utils/geodesic.cpp
         src/utils/map_projection_impl.cpp
 )
-ament_target_dependencies(px4_ros2_cpp ament_index_cpp Eigen3 rclcpp px4_msgs)
+target_link_libraries(px4_ros2_cpp PUBLIC ament_index_cpp::ament_index_cpp Eigen3::Eigen rclcpp::rclcpp ${px4_msgs_TARGETS})
 
 ament_export_targets(px4_ros2_cpp HAS_LIBRARY_TARGET)
 ament_export_dependencies(
@@ -116,7 +116,7 @@ if(BUILD_TESTING)
             test/integration/util.cpp
     )
     include_directories(include)
-    ament_target_dependencies(integration_utils rclcpp px4_msgs)
+    target_link_libraries(integration_utils PUBLIC rclcpp::rclcpp ${px4_msgs_TARGETS})
 
     ament_add_gtest(integration_tests
             test/integration/arming_check.cpp
@@ -137,7 +137,7 @@ if(BUILD_TESTING)
             test/unit/utils/util.cpp
     )
     include_directories(include)
-    ament_target_dependencies(unit_utils Eigen3)
+    target_link_libraries(unit_utils PUBLIC Eigen3::Eigen)
 
     ament_add_gtest(${PROJECT_NAME}_unit_tests
             test/unit/global_navigation.cpp
@@ -150,10 +150,7 @@ if(BUILD_TESTING)
             test/unit/utils/map_projection_impl.cpp
     )
     target_include_directories(${PROJECT_NAME}_unit_tests PRIVATE ${CMAKE_CURRENT_LIST_DIR})
-    target_link_libraries(${PROJECT_NAME}_unit_tests ${PROJECT_NAME} unit_utils)
-    ament_target_dependencies(${PROJECT_NAME}_unit_tests
-            rclcpp px4_msgs
-    )
+    target_link_libraries(${PROJECT_NAME}_unit_tests ${PROJECT_NAME} unit_utils rclcpp::rclcpp ${px4_msgs_TARGETS})
 endif()
 
 ament_package()


### PR DESCRIPTION
ROS 2 is deprecating `ament_target_dependencies` with a preference to switch to `target_link_libraries`. This updates the CMakeLists to use `target_link_libraries`. Everything builds correctly. 