### PR TITLE
Replace apt with apt-get to reduce warnings in the CI logs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: install clang tidy
         run: |
-          sudo apt install --yes -qq clang-tidy
+          sudo apt-get install --yes -qq clang-tidy
       - name: clang tidy
         run: |
           ROS_WS_DIR="$(readlink -f ${{ steps.ros-build.outputs.ros-workspace-directory-name }})"

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install doxygen
-        run: sudo apt update && sudo apt install -y doxygen
+        run: sudo apt-get update && sudo apt-get install -y doxygen
 
       - name: Run doxygen
         run: ./scripts/run-doxygen.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: true
 
       - name: Install system hooks
-        run: sudo apt update && sudo apt install -qq ament-cmake-uncrustify ament-lint
+        run: sudo apt-get update && sudo apt-get install -qq ament-cmake-uncrustify ament-lint
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.0
 


### PR DESCRIPTION
Right now the CI has the following warning messages:
```
 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```

This removes some of the warning messages by using `apt-get` instead of `apt` to make the CI logs cleaner to read. 