### PR TITLE
Switch to self-hosted runners

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ defaults:
 jobs:
   build_and_test:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: [runs-on,"runner=${{ vars.RUNSON_CI_BUILDER_DEFAULT_X64 }}","run-id=${{ github.run_id }}"]
     container:
       image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [runs-on,"runner=${{ vars.RUNSON_CI_RUNNER_DEFAULT }}","run-id=${{ github.run_id }}"]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Update the CI to use self-hosted runners

- [x] Requires https://github.com/Auterion/ros-debian-workflow/pull/11