### PR TITLE
VTOL: robustify against NaN deceleration

### DIFF
--- a/px4_ros2_cpp/src/control/vtol.cpp
+++ b/px4_ros2_cpp/src/control/vtol.cpp
@@ -165,6 +165,20 @@ float VTOL::computePitchSetpointDuringBacktransition(
     _decel_error_bt_int = 0.f;
   }
 
+  if (std::isnan(deceleration)) {
+
+    // If no local position samples were ever received by
+    // _vehicle_local_position_sub, the deceleration here is NaN. To guard
+    // against that, we return the pitch setpoint but don't update it in that
+    // case.
+
+    // Usually we will then have valid local position within a couple samples.
+    // To avoid this case entirely, instantiate the VTOL object significantly
+    // before the first call of this function.
+
+    return _decel_error_bt_int;
+  }
+
   // Update back-transition deceleration error integrator
   _decel_error_bt_int +=
     (_config.back_transition_deceleration_setpoint_to_pitch_i * deceleration_error) * dt;


### PR DESCRIPTION
Sporadically with SDK commanded backtransitions, it applied maximum pitch / deceleration, even though the deceleration setpoint given to the `auterion::vtol::TransitionSetpoint` is always smooth and below 2 m/s^2. After some print debugging (*) I found that the deceleration used here is sometimes NaN in the first couple samples. This means that the pitch setpoint _stays_ NaN (until reset to 0 in the next backtransition), and the NaN makes its way to the acceleration given to PX4 via trajectory setpoint. 

The proposed fix continues applying the existing pitch setpoint in that case. If NaN decelerations occur at the start of the backtransition, we delay the deceleration until we have valid deceleration measurements. 

Is the case of sustained NaN values possible / likely enough to warrant some additional more robust error handling? 


<details>
<summary>* With <a href=https://github.com/Auterion/px4-ros2-interface-lib/commit/b4cdf3a9f6ff3988c4ee353d61790228f446d2f2>this</a> change, we get this output: </summary>
<br>


px4_ros2_cpp computePitchSetpointDuringBacktransition: _decel_error_bt_int is NaN.
deceleration_setpoint: 1.51363
deceleration: -nan
deceleration_error: -nan
dt: 0
I gain: 0.1
upper limit: 0.3
px4_ros2_cpp computePitchSetpointDuringBacktransition: _decel_error_bt_int is NaN.
deceleration_setpoint: 1.51192
deceleration: -nan
deceleration_error: -nan
dt: 0.00995455
I gain: 0.1
upper limit: 0.3
px4_ros2_cpp computePitchSetpointDuringBacktransition: _decel_error_bt_int is NaN.
deceleration_setpoint: 1.52329
deceleration: 0.073529
deceleration_error: 1.44976
dt: 0.0101022
I gain: 0.1
upper limit: 0.3
px4_ros2_cpp computePitchSetpointDuringBacktransition: _decel_error_bt_int is NaN.
deceleration_setpoint: 1.51842
deceleration: 0.073529
deceleration_error: 1.44489
dt: 0.00998235
I gain: 0.1
upper limit: 0.3
px4_ros2_cpp computePitchSetpointDuringBacktransition: _decel_error_bt_int is NaN.
deceleration_setpoint: 1.53568
deceleration: -1.00205
deceleration_error: 2.53774
dt: 0.00993576
I gain: 0.1
upper limit: 0.3


</details>