### PR TITLE
Add rmw_zenoh_cpp support by using RIHS01 hashes

### DIFF
--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -20,6 +20,41 @@ find_package(rclcpp REQUIRED)
 find_package(px4_msgs REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(ament_index_cpp REQUIRED)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+if($ENV{ROS_DISTRO} STREQUAL "humble")
+    add_compile_definitions(ROS2_HUMBLE)
+endif()
+
+ament_index_get_resource(MESSAGE_FILES "rosidl_interfaces" px4_msgs)
+
+# Split the message files into a list
+string(REPLACE "\n" ";" msg_file_list "${MESSAGE_FILES}")
+
+set(PX4_MSG_FILES "")
+foreach(file ${msg_file_list})
+  if("${file}" MATCHES "^msg/(.*\\.msg)$")
+    string(REGEX REPLACE "^msg/" "" cleaned_file "${file}")
+    list(APPEND PX4_MSG_FILES "${cleaned_file}")
+  endif()
+endforeach()
+
+# Convert list to Python-style list string
+string(REPLACE ";" "','" MESSAGE_NAMES_QUOTED "${PX4_MSG_FILES}")
+set(MESSAGE_NAMES_PYTHON "[\'${MESSAGE_NAMES_QUOTED}\']")
+
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/px4_all_messages.hpp
+  COMMAND ${Python3_EXECUTABLE} -m em
+    -D message_names=\"${MESSAGE_NAMES_PYTHON}\"
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/components/px4_all_messages.hpp.em
+    > ${CMAKE_CURRENT_BINARY_DIR}/px4_all_messages.hpp
+  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/components/px4_all_messages.hpp.em
+  COMMENT "Generating px4_all_messages.hpp using empy"
+)
+
+add_custom_target(generate_px4_header DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/px4_all_messages.hpp)
 
 include_directories(include SYSTEM ${Eigen3_INCLUDE_DIRS})
 set(HEADER_FILES
@@ -116,6 +151,8 @@ add_library(px4_ros2_cpp
         src/utils/geodesic.cpp
         src/utils/map_projection_impl.cpp
 )
+add_dependencies(px4_ros2_cpp generate_px4_header)
+target_include_directories(px4_ros2_cpp PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 target_link_libraries(px4_ros2_cpp PUBLIC ament_index_cpp::ament_index_cpp Eigen3::Eigen rclcpp::rclcpp ${px4_msgs_TARGETS})
 
 ament_export_targets(px4_ros2_cpp HAS_LIBRARY_TARGET)

--- a/px4_ros2_cpp/include/px4_ros2/components/message_compatibility_check.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/message_compatibility_check.hpp
@@ -66,7 +66,20 @@ struct MessageCompatibilityTopic
 };
 
 /**
- * Check for a set of messages that the definition matches with the one that PX4 is using.
+ * @brief Check for a set of messages that match the definitions used by PX4.
+ *
+ * This function verifies that the message definitions are compatible with those
+ * expected by the PX4 ROS 2 interface library. It returns true if all definitions match.
+ *
+ * @note Compared to rmw_fastrtps_cpp, rmw_zenoh_cpp behaves differently.
+ * PX4 Zenoh allows flexible topic name mapping, so topic names are not fixed.
+ * In this case, the function only verifies the hashes of the message types
+ * to ensure binary compatibility between the FMU and ROS 2.
+ *
+ * ROS 2 Humble does not support type hash, so no type checking will occur
+ * when using Zenoh. It is recommended to use Zenoh with ROS 2 Jazzy or later
+ * to ensure proper type compatibility verification.
+ *
  * @return true on success
  * @ingroup components
  */

--- a/px4_ros2_cpp/include/px4_ros2/utils/message_version.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/message_version.hpp
@@ -32,6 +32,18 @@ struct HasMessageVersion : std::false_type {};
 template<typename T>
 struct HasMessageVersion<T, std::void_t<decltype(T::MESSAGE_VERSION)>>: std::true_type {};
 
+
+/**
+ * @brief Checks if the current RMW (ROS Middleware) implementation is `rmw_zenoh_cpp`.
+ *
+ * @return `true` if the current RMW implementation is `rmw_zenoh_cpp`, `false` otherwise.
+ */
+static bool isRmwZenoh()
+{
+  const char * rmw_id = rmw_get_implementation_identifier();
+  return std::string(rmw_id) == "rmw_zenoh_cpp";
+}
+
 /**
  * @brief Retrieves the version suffix for a given message type.
  *
@@ -41,6 +53,9 @@ struct HasMessageVersion<T, std::void_t<decltype(T::MESSAGE_VERSION)>>: std::tru
 template<typename T>
 std::string getMessageNameVersion()
 {
+  if (isRmwZenoh()) {
+    return "";
+  }
   if constexpr (HasMessageVersion<T>::value) {
     if (T::MESSAGE_VERSION == 0) {return "";}
     return "_v" + std::to_string(T::MESSAGE_VERSION);

--- a/px4_ros2_cpp/src/components/px4_all_messages.hpp.em
+++ b/px4_ros2_cpp/src/components/px4_all_messages.hpp.em
@@ -1,0 +1,41 @@
+#ifndef PX4_MSGS_ALL_MESSAGES_HPP
+#define PX4_MSGS_ALL_MESSAGES_HPP
+
+// Auto-generated header including all PX4 message types
+@{
+import re
+
+def camel_to_snake(name):
+    return re.sub(r'(?<!^)(?=[A-Z])', '_', name).lower()
+
+for msg in message_names:
+    print("#include <px4_msgs/msg/" + camel_to_snake(msg.removesuffix(".msg")) + ".hpp>")
+}@
+
+struct TopicTypeSupport
+{
+  const char * topic_type_name;
+  const rosidl_message_type_support_t * ts_handle;
+};
+
+static TopicTypeSupport all_px4_ros2_messages[] = {
+@{
+for msg_file in message_names:
+    msg = msg_file.removesuffix(".msg")
+    print("  {\"px4_msgs/msg/" + msg + "\",")
+    print("    rosidl_typesupport_cpp::get_message_type_support_handle<px4_msgs::msg::" + msg + ">()},")
+}@
+};
+
+const TopicTypeSupport* find_type_support(const std::string& type_name)
+{
+  for (const auto& entry : all_px4_ros2_messages) {
+    if (type_name == entry.topic_type_name) {
+      return &entry;
+    }
+  }
+  return nullptr; // Not found
+}
+
+
+#endif // PX4_MSGS_ALL_MESSAGES_HPP


### PR DESCRIPTION
When using PX4 with rmw_zenoh_cpp with PX4/PX4-Autopilot#24476
We use RIHS01 hashes instead to check type support

This patch fixes that so that px4-ros2-interface-lib works with rmw_zenoh_cpp