### PR TITLE
Add change motor spin direction function

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
@@ -9,6 +9,7 @@
 #include "overrides.hpp"
 
 #include <rclcpp/rclcpp.hpp>
+#include <px4_msgs/msg/actuator_motors.hpp>
 #include <px4_msgs/msg/vehicle_status.hpp>
 #include <px4_msgs/msg/vehicle_command.hpp>
 #include <px4_msgs/msg/vehicle_command_ack.hpp>
@@ -47,6 +48,12 @@ public:
   {
     FailsafeActivated,
     Other
+  };
+
+  enum class DshotSpinDirection
+  {
+    SpinDirection1,
+    SpinDirection2
   };
 
   ModeExecutorBase(
@@ -105,6 +112,19 @@ public:
   void disarm(const CompletedCallback & on_completed, bool forced = false);
   void waitReadyToArm(const CompletedCallback & on_completed);
   void waitUntilDisarmed(const CompletedCallback & on_completed);
+
+  /**
+   * Change the motor spin direction.
+   * This function is useful for turtle mode after a crash. In fact, when the drone has flipped
+   * (tilt angle > 90°), there is a need to turtle mode. To do that, there is a need to turn some motors
+   * in the opposition direction to the default one for a normal flight.
+   *
+   * @params: the motor number (motor_num) and the spin direction
+   *
+   */
+  void changeMotorSpinDirection(
+    const CompletedCallback & on_completed, int motor_num,
+    int spin_direction);
 
   bool isInCharge() const {return _is_in_charge;}
 
@@ -200,6 +220,8 @@ private:
   bool _was_never_activated{true};
   ModeBase::ModeID _prev_nav_state{ModeBase::kModeIDInvalid};
   uint8_t _prev_failsafe_defer_state{px4_msgs::msg::VehicleStatus::FAILSAFE_DEFER_STATE_DISABLED};
+
+  static constexpr int kMaxNumMotors = px4_msgs::msg::ActuatorMotors::NUM_CONTROLS;
 
   ConfigOverrides _config_overrides;
 };

--- a/px4_ros2_cpp/src/components/mode_executor.cpp
+++ b/px4_ros2_cpp/src/components/mode_executor.cpp
@@ -344,6 +344,35 @@ void ModeExecutorBase::waitUntilDisarmed(const CompletedCallback & on_completed)
     on_completed);
 }
 
+void ModeExecutorBase::changeMotorSpinDirection(
+  const CompletedCallback & on_completed,
+  int motor_num, int spin_direction)
+{
+  float param1 = NAN;
+  switch (spin_direction) {
+    case int(DshotSpinDirection::SpinDirection1):
+      param1 = 3.5;
+      break;
+
+    case int(DshotSpinDirection::SpinDirection2):
+      param1 = 4.5;
+      break;
+  }
+
+  const float param2 = NAN;
+  const float param3 = NAN;
+  const float param4 = NAN;
+
+  float param5 = (motor_num >= 0 && motor_num < kMaxNumMotors) ? motor_num - 0.5 : NAN;
+
+  const Result result = sendCommandSync(
+    px4_msgs::msg::VehicleCommand::VEHICLE_CMD_CONFIGURE_ACTUATOR,
+    param1, param2, param3, param4, param5);
+
+  on_completed(result);
+  return;
+}
+
 void ModeExecutorBase::vehicleStatusUpdated(const px4_msgs::msg::VehicleStatus::UniquePtr & msg)
 {
   // Update state

--- a/px4_ros2_cpp/src/control/setpoint_types/fixedwing_lateral_longitudinal.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/fixedwing_lateral_longitudinal.cpp
@@ -14,20 +14,24 @@ FwLateralLongitudinalSetpointType::FwLateralLongitudinalSetpointType(Context & c
 {
   _fw_lateral_sp_pub =
     context.node().create_publisher<px4_msgs::msg::FixedWingLateralSetpoint>(
-    context.topicNamespacePrefix() + "fmu/in/fixed_wing_lateral_setpoint" + px4_ros2::getMessageNameVersion<px4_msgs::msg::FixedWingLateralSetpoint>(),
+    context.topicNamespacePrefix() + "fmu/in/fixed_wing_lateral_setpoint" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::FixedWingLateralSetpoint>(),
     1);
   _fw_longitudinal_sp_pub =
     context.node().create_publisher<px4_msgs::msg::FixedWingLongitudinalSetpoint>(
-    context.topicNamespacePrefix() + "fmu/in/fixed_wing_longitudinal_setpoint" + px4_ros2::getMessageNameVersion<px4_msgs::msg::FixedWingLongitudinalSetpoint>(),
+    context.topicNamespacePrefix() + "fmu/in/fixed_wing_longitudinal_setpoint" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::FixedWingLongitudinalSetpoint>(),
     1);
 
   _lateral_control_configuration_pub =
     context.node().create_publisher<px4_msgs::msg::LateralControlConfiguration>(
-    context.topicNamespacePrefix() + "fmu/in/lateral_control_configuration" + px4_ros2::getMessageNameVersion<px4_msgs::msg::LateralControlConfiguration>(),
+    context.topicNamespacePrefix() + "fmu/in/lateral_control_configuration" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::LateralControlConfiguration>(),
     1);
   _longitudinal_control_configuration_pub =
     context.node().create_publisher<px4_msgs::msg::LongitudinalControlConfiguration>(
-    context.topicNamespacePrefix() + "fmu/in/longitudinal_control_configuration" + px4_ros2::getMessageNameVersion<px4_msgs::msg::LongitudinalControlConfiguration>(),
+    context.topicNamespacePrefix() + "fmu/in/longitudinal_control_configuration" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::LongitudinalControlConfiguration>(),
     1);
 }
 

--- a/px4_ros2_cpp/src/control/vtol.cpp
+++ b/px4_ros2_cpp/src/control/vtol.cpp
@@ -19,11 +19,13 @@ VTOL::VTOL(Context & context, const VTOLConfig & config)
 : _node(context.node()), _config(config)
 {
   _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
-    context.topicNamespacePrefix() + "fmu/in/vehicle_command" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
+    context.topicNamespacePrefix() + "fmu/in/vehicle_command" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
     1);
 
   _vtol_vehicle_status_sub = _node.create_subscription<px4_msgs::msg::VtolVehicleStatus>(
-    context.topicNamespacePrefix() + "fmu/out/vtol_vehicle_status" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VtolVehicleStatus>(),
+    context.topicNamespacePrefix() + "fmu/out/vtol_vehicle_status" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VtolVehicleStatus>(),
     rclcpp::QoS(10).best_effort(),
     [this](px4_msgs::msg::VtolVehicleStatus::UniquePtr msg) {
 
@@ -48,7 +50,8 @@ VTOL::VTOL(Context & context, const VTOLConfig & config)
     });
 
   _vehicle_local_position_sub = _node.create_subscription<px4_msgs::msg::VehicleLocalPosition>(
-    context.topicNamespacePrefix() + "fmu/out/vehicle_local_position" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleLocalPosition>(),
+    context.topicNamespacePrefix() + "fmu/out/vehicle_local_position" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleLocalPosition>(),
     rclcpp::QoS(10).best_effort(),
     [this](px4_msgs::msg::VehicleLocalPosition::UniquePtr msg) {
       _vehicle_heading = msg->heading;


### PR DESCRIPTION
This function is useful for turtle mode after a crash. In fact, when the drone has flipped (tilt angle > 90°), there is a need to turtle mode. To do that, there is a need to turn some motors in the opposite direction to the default one for a normal flight.