### PR TITLE
Remove deprecated ament_target_dependencies

### DIFF
--- a/examples/cpp/modes/vtol/CMakeLists.txt
+++ b/examples/cpp/modes/vtol/CMakeLists.txt
@@ -21,9 +21,9 @@ include_directories(include ${Eigen3_INCLUDE_DIRS})
 add_executable(example_mode_vtol
         src/main.cpp)
 target_link_libraries(example_mode_vtol PUBLIC
-	Eigen3::Eigen
-	px4_ros2_cpp::px4_ros2_cpp
-	rclcpp::rclcpp)
+        Eigen3::Eigen
+        px4_ros2_cpp::px4_ros2_cpp
+        rclcpp::rclcpp)
 
 install(TARGETS
         example_mode_vtol


### PR DESCRIPTION
This fixes a build warning on kilted and rolling related to how ament_target_dependencies has become deprecated. 

Build warning:
```
--- stderr: example_mode_vtol_cpp                                       
CMake Deprecation Warning at /opt/ros/kilted/share/ament_cmake_target_dependencies/cmake/ament_target_dependencies.cmake:87 (message):
  ament_target_dependencies() is deprecated.  Use target_link_libraries()
  with modern CMake targets instead.  Try replacing this call with:

    target_link_libraries(example_mode_vtol PUBLIC
      px4_ros2_cpp::px4_ros2_cpp
      rclcpp::rclcpp
    )

Call Stack (most recent call first):
  CMakeLists.txt:23 (ament_target_dependencies)


---
Finished <<< example_mode_vtol_cpp [23.8s]
```