### PR TITLE
Mode onfiguration to make a mode not user selectable

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
@@ -92,11 +92,13 @@ public:
     // NOLINTNEXTLINE allow implicit conversion
     Settings(
       std::string mode_name, bool want_activate_even_while_disarmed = false,
-      ModeID request_replace_internal_mode = kModeIDInvalid)
+      ModeID request_replace_internal_mode = kModeIDInvalid, bool request_user_selectable = true)
     : name(std::move(mode_name)), activate_even_while_disarmed(want_activate_even_while_disarmed),
+      user_selectable(request_user_selectable),
       replace_internal_mode(request_replace_internal_mode) {}
     std::string name;             ///< Name of the mode with length < 25 characters
     bool activate_even_while_disarmed{true};             ///< If true, the mode is also activated while disarmed if selected
+    bool user_selectable{true};                     ///< If true, the mode is selectable by the user
     ModeID replace_internal_mode{kModeIDInvalid};             ///< Can be used to replace an fmu-internal mode
   };
 

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -95,6 +95,7 @@ RegistrationSettings ModeBase::getRegistrationSettings() const
     settings.enable_replace_internal_mode = true;
     settings.replace_internal_mode = _settings.replace_internal_mode;
   }
+  settings.user_selectable = _settings.user_selectable;
 
   return settings;
 }

--- a/px4_ros2_cpp/src/components/registration.cpp
+++ b/px4_ros2_cpp/src/components/registration.cpp
@@ -65,6 +65,7 @@ bool Registration::doRegister(const RegistrationSettings & settings)
   request.enable_replace_internal_mode = settings.enable_replace_internal_mode;
   request.replace_internal_mode = settings.replace_internal_mode;
   request.activate_mode_immediately = settings.activate_mode_immediately;
+  request.not_user_selectable = !settings.user_selectable;
   request.px4_ros2_api_version = kLatestPX4ROS2ApiVersion;
 
   std::random_device rd;

--- a/px4_ros2_cpp/src/components/registration.hpp
+++ b/px4_ros2_cpp/src/components/registration.hpp
@@ -25,6 +25,7 @@ struct RegistrationSettings
   bool enable_replace_internal_mode{false};
   px4_ros2::ModeBase::ModeID replace_internal_mode{};
   bool activate_mode_immediately{false};
+  bool user_selectable{true};
 };
 
 class Registration


### PR DESCRIPTION
Some modes should only be run within the context of a mode executor and the user should not be able to select them in the GCS.

With this change, the external component registration request can be used to set if a mode is selectable or not.