### PR TITLE
Add configuration option to control auto set home in PX4

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
@@ -132,6 +132,8 @@ public:
    */
   bool deferFailsafesSync(bool enabled, int timeout_s = 0);
 
+  bool controlAutoSetHome(bool enabled);
+
 protected:
   void setSkipMessageCompatibilityCheck() {_skip_message_compatibility_check = true;}
   void overrideRegistration(const std::shared_ptr<Registration> & registration);

--- a/px4_ros2_cpp/include/px4_ros2/components/overrides.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/overrides.hpp
@@ -27,6 +27,7 @@ private:
 
   friend class ModeBase;
   friend class ModeExecutorBase;
+  void controlAutoSetHome(bool enabled);
   void deferFailsafes(bool enabled, int timeout_s = 0);
   void setup(uint8_t type, uint8_t id);
 

--- a/px4_ros2_cpp/include/px4_ros2/mission/mission_executor.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/mission/mission_executor.hpp
@@ -106,6 +106,8 @@ public:
    */
   bool deferFailsafes(bool enabled, int timeout_s = 0);
 
+  bool controlAutoSetHome(bool enabled);
+
   /**
    * Abort a currently running mission. This will trigger the onFailure action (which can be customized).
    * The abort reason will be set to 'other'.
@@ -432,6 +434,15 @@ public:
       return false;
     }
     return _mission_executor.deferFailsafes(enabled, timeout_s);
+  }
+
+  bool controlAutoSetHome(bool enabled)
+  {
+    if (!_valid) {
+      RCLCPP_WARN(_mission_executor._node.get_logger(), "ActionHandler is not valid anymore");
+      return false;
+    }
+    return _mission_executor.controlAutoSetHome(enabled);
   }
 
   /**

--- a/px4_ros2_cpp/src/components/mode_executor.cpp
+++ b/px4_ros2_cpp/src/components/mode_executor.cpp
@@ -457,6 +457,12 @@ bool ModeExecutorBase::deferFailsafesSync(bool enabled, int timeout_s)
   return true;
 }
 
+bool ModeExecutorBase::controlAutoSetHome(bool enabled)
+{
+  _config_overrides.controlAutoSetHome(enabled);
+  return true;
+}
+
 void ModeExecutorBase::overrideRegistration(const std::shared_ptr<Registration> & registration)
 {
   assert(!_registration->registered());

--- a/px4_ros2_cpp/src/components/overrides.cpp
+++ b/px4_ros2_cpp/src/components/overrides.cpp
@@ -33,6 +33,12 @@ void ConfigOverrides::deferFailsafes(bool enabled, int timeout_s)
   update();
 }
 
+void ConfigOverrides::controlAutoSetHome(bool enabled)
+{
+  _current_overrides.disable_auto_set_home = !enabled;
+  update();
+}
+
 void ConfigOverrides::update()
 {
   if (_is_setup) {

--- a/px4_ros2_cpp/src/mission/mission_executor.cpp
+++ b/px4_ros2_cpp/src/mission/mission_executor.cpp
@@ -199,6 +199,11 @@ void MissionExecutor::onReadynessUpdate(
   checkReadynessAndReport();
 }
 
+bool MissionExecutor::controlAutoSetHome(bool enabled)
+{
+  return _mode_executor->controlAutoSetHome(enabled);
+}
+
 bool MissionExecutor::deferFailsafes(bool enabled, int timeout_s)
 {
   return _mode_executor->deferFailsafesSync(enabled, timeout_s);


### PR DESCRIPTION
There can be mission items that land the vehicle but the home position should not be updated to the landing location.

With this change, a configuration override can be set to disable the automatic set home position logic in PX4.