### PR TITLE
Extend default action for takeoff with a takeoff altitude

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/mission/actions/default_actions.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/mission/actions/default_actions.hpp
@@ -60,7 +60,11 @@ public:
     const std::shared_ptr<ActionHandler> & handler, const ActionArguments & arguments,
     const std::function<void()> & on_completed) override
   {
-    handler->runMode(ModeBase::kModeIDTakeoff, on_completed);
+    if (arguments.contains("altitude")) {
+      handler->runModeTakeoff(arguments.at<float>("altitude"), NAN, on_completed);
+    } else {
+      handler->runMode(ModeBase::kModeIDTakeoff, on_completed);
+    }
   }
 };
 

--- a/px4_ros2_cpp/include/px4_ros2/mission/mission_executor.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/mission/mission_executor.hpp
@@ -226,6 +226,8 @@ private:
   void runMode(
     ModeBase::ModeID mode_id,
     const std::function<void()> & on_completed, const std::function<void()> & on_failure = nullptr);
+  void runModeTakeoff(float altitude, float heading,
+    const std::function<void()> & on_completed, const std::function<void()> & on_failure = nullptr);
   void runAction(
     const std::string & action_name, const ActionArguments & arguments,
     const std::function<void()> & on_completed);
@@ -346,6 +348,15 @@ public:
       return;
     }
     _mission_executor.runMode(mode_id, on_completed, on_failure);
+  }
+  void runModeTakeoff(float altitude, float heading,
+    const std::function<void()> & on_completed, const std::function<void()> & on_failure = nullptr)
+  {
+    if (!_valid) {
+      RCLCPP_WARN(_mission_executor._node.get_logger(), "ActionHandler is not valid anymore");
+      return;
+    }
+    _mission_executor.runModeTakeoff(altitude, heading, on_completed, on_failure);
   }
   void runAction(
     const std::string & action_name, const ActionArguments & arguments,


### PR DESCRIPTION
The takeoff mode in PX4 ascends to a default height above the takeoff point.

With this change, an optional altitude argument is added to enable takeoffs to a mission specific altitude (MSL).