### PR TITLE
fix: unresolved link to "value"

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/utils/message_version.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/message_version.hpp
@@ -20,7 +20,7 @@ namespace px4_ros2
 /**
  * @brief Trait to check if a message type `T` has a `MESSAGE_VERSION` constant.
  *
- * If `T` has `MESSAGE_VERSION`, `HasMessageVersion<T>::value` is `true`;
+ * If `T` has `MESSAGE_VERSION`, \c HasMessageVersion<T>::value is `true`;
  * otherwise it is `false`.
  *
  * @tparam T The message type to check.


### PR DESCRIPTION
Doxygen was giving the error:

```
/home/guillaume/repos/px4-ros2-interface-lib/px4_ros2_cpp/include/px4_ros2/utils/message_version.hpp:23: warning: explicit link request to 'value' could not be resolved
```

This prevents doxygen from the trying to link the `value` symbol and instead just presents it as inline code. 