### PR TITLE
fix(scripts): message compat script should handle missing messages

### DIFF
--- a/scripts/check-message-compatibility.py
+++ b/scripts/check-message-compatibility.py
@@ -20,6 +20,8 @@ def message_fields_str_for_message_hash(topic_type: str, msgs_dir: str) -> str:
     and recursively processes nested types to generate a string representation of all fields.
     """
     filename = find_file_in_subfolders(f"{msgs_dir}/", f"{topic_type}.msg")
+    if filename is None:
+        raise FileNotFoundError(f"Message definition file {topic_type}.msg not found in {msgs_dir}")
     try:
         with open(filename, 'r') as file:
             text = file.read()
@@ -149,12 +151,18 @@ def main(repo1: str, repo2: str, verbose: bool = False):
 
     # Find mismatches
     incompatible_types = []
+    missing_types = []
     for msg_type in messages_types:
-        if message_hash(msg_type, repo1) != message_hash(msg_type, repo2):
-            incompatible_types.append(msg_type)
+        try:
+            if message_hash(msg_type, repo1) != message_hash(msg_type, repo2):
+                incompatible_types.append(msg_type)
+        except FileNotFoundError as e:
+            print(f"Error: {e}")
+            missing_types.append(msg_type)
 
     # Print result
-    if not incompatible_types:
+    success = not incompatible_types and not missing_types
+    if success:
         print("OK! Messages are compatible.")
         sys.exit(0)
     else:
@@ -165,9 +173,13 @@ def main(repo1: str, repo2: str, verbose: bool = False):
                 compare_files(file1, file2)
             print("Note: The printed diff includes all content differences. "
                   "The computed check is less sensitive to formatting and comments.", end='\n\n')
-        print("FAILED! Some files differ:")
-        for msg_type in incompatible_types:
-            print(f" - {msg_type}.msg")
+        print("FAILED!", end=' ')
+        if incompatible_types:
+            print("Some files differ:")
+            print("\n".join(f" - {msg_type}.msg" for msg_type in incompatible_types))
+        if missing_types:
+            print("The following message types were not found in one of the repositories:")
+            print("\n".join(f" - {msg_type}.msg" for msg_type in missing_types))
         sys.exit(1)
 
 


### PR DESCRIPTION
### Problem

The `check-message-compatibility.py` script does not handle cases where one of the messages to check is missing from either input repository:

```
  File "/home/guillaume/repos/px4-ros2-interface-lib/./scripts/check-message-compatibility.py", line 24, in message_fields_str_for_message_hash
    with open(filename, 'r') as file:
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

### Changes

This adds handling of the missing message case, which the script will also flag as an incompatibility. Now the output may looks something like:

```
$ ./scripts/check-message-compatibility.py ../PX4/ ../px4_msgs
Error: Message definition file ActuatorServos.msg not found in ../PX4/
Error: Message definition file VehicleGlobalPosition.msg not found in ../px4_msgs
FAILED! Some files differ:
 - AirspeedValidated.msg
The following message types were not found in one of the repositories:
 - ActuatorServos.msg
 - VehicleGlobalPosition.msg
```

