### PR TITLE
Mode checks improvements

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/components/health_and_arming_checks.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/health_and_arming_checks.hpp
@@ -129,6 +129,7 @@ private:
   std::shared_ptr<Registration> _registration;
   CheckCallback _check_callback;
   bool _check_triggered{true};
+  bool _first_request{true};
 
   rclcpp::Subscription<px4_msgs::msg::ArmingCheckRequest>::SharedPtr _arming_check_request_sub;
   rclcpp::Publisher<px4_msgs::msg::ArmingCheckReply>::SharedPtr _arming_check_reply_pub;

--- a/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
@@ -167,6 +167,8 @@ protected:
 
   void disableWatchdogTimer() {_health_and_arming_checks.disableWatchdogTimer();}
 
+  bool defaultMessageCompatibilityCheck();
+
 private:
   void addSetpointType(SetpointBase * setpoint) override;
   void setRequirement(const RequirementFlags & requirement_flags) override;

--- a/px4_ros2_cpp/src/components/health_and_arming_checks.cpp
+++ b/px4_ros2_cpp/src/components/health_and_arming_checks.cpp
@@ -49,7 +49,18 @@ HealthAndArmingChecks::HealthAndArmingChecks(
 
         reply.timestamp = 0; // Let PX4 set the timestamp
         _arming_check_reply_pub->publish(reply);
-        _check_triggered = true;
+
+        // Check if our registration id is still valid. If not, we still send the reply,
+        // as it might be flagged as unresponsive, but we don't update the timer check.
+        // The first request might not have the bit set yet.
+        if (_first_request || (msg->valid_registrations_mask & (1U << reply.registration_id))) {
+          _check_triggered = true;
+        } else {
+          RCLCPP_ERROR_ONCE(
+            _node.get_logger(), "Registration id %i is flagged as invalid (only printed once)",
+            reply.registration_id);
+        }
+        _first_request = false;
 
       } else {
         RCLCPP_DEBUG(_node.get_logger(), "...not registered yet");
@@ -72,6 +83,7 @@ bool HealthAndArmingChecks::doRegister(const std::string & name)
   RegistrationSettings settings{};
   settings.name = name;
   settings.register_arming_check = true;
+  _first_request = true;
   return _registration->doRegister(settings);
 }
 

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -64,7 +64,7 @@ bool ModeBase::doRegister()
   assert(!_registration->registered());
 
   if (!_skip_message_compatibility_check && (!waitForFMU(node(), 15s, topicNamespacePrefix()) ||
-    !messageCompatibilityCheck(node(), {ALL_PX4_ROS2_MESSAGES}, topicNamespacePrefix())))
+    !defaultMessageCompatibilityCheck()))
   {
     return false;
   }
@@ -291,6 +291,14 @@ void ModeBase::activateSetpointType(SetpointBase & setpoint)
   setpoint.getConfiguration().fillControlMode(control_mode);
   control_mode.timestamp = 0; // Let PX4 set the timestamp
   _config_control_setpoints_pub->publish(control_mode);
+}
+
+bool ModeBase::defaultMessageCompatibilityCheck()
+{
+  // Call the compatibility check only once and store the result (in case there are multiple modes)
+  static const bool result = messageCompatibilityCheck(
+    node(), {ALL_PX4_ROS2_MESSAGES}, topicNamespacePrefix());
+  return result;
 }
 
 void ModeBase::addSetpointType(SetpointBase * setpoint)

--- a/px4_ros2_cpp/src/components/mode_executor.cpp
+++ b/px4_ros2_cpp/src/components/mode_executor.cpp
@@ -54,7 +54,7 @@ bool ModeExecutorBase::doRegister()
   assert(!_registration->registered());
 
   if (!_skip_message_compatibility_check && (!waitForFMU(node(), 15s, _topic_namespace_prefix) ||
-    !messageCompatibilityCheck(node(), {ALL_PX4_ROS2_MESSAGES}, _topic_namespace_prefix)))
+    !_owned_mode.defaultMessageCompatibilityCheck()))
   {
     return false;
   }


### PR DESCRIPTION
- check if registration is still valid
- only call messageCompatibilityCheck once when using multiple modes and/or executors. The checks require about 1s on my setup (DDS bridge over ethernet).

Requires https://github.com/PX4/PX4-Autopilot/pull/25465