### PR TITLE
mode: use shared vehicle_status subscription between modes and executors

### DIFF
--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(px4_ros2_cpp
         src/components/mode_executor.cpp
         src/components/overrides.cpp
         src/components/registration.cpp
+        src/components/vehicle_status.cpp
         src/components/wait_for_fmu.cpp
         src/control/peripheral_actuators.cpp
         src/control/vtol.cpp
@@ -167,6 +168,7 @@ if(BUILD_TESTING)
             test/unit/utils/geodesic.cpp
             test/unit/utils/geometry.cpp
             test/unit/utils/map_projection_impl.cpp
+            test/unit/vehicle_status.cpp
     )
     target_include_directories(${PROJECT_NAME}_unit_tests PRIVATE ${CMAKE_CURRENT_LIST_DIR})
     target_link_libraries(${PROJECT_NAME}_unit_tests ${PROJECT_NAME} unit_utils rclcpp::rclcpp ${px4_msgs_TARGETS})

--- a/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
@@ -19,6 +19,7 @@
 
 class Registration;
 struct RegistrationSettings;
+class SharedVehicleStatusToken;
 
 namespace px4_ros2
 {
@@ -104,7 +105,7 @@ public:
     rclcpp::Node & node, Settings settings,
     const std::string & topic_namespace_prefix = "");
   ModeBase(const ModeBase &) = delete;
-  virtual ~ModeBase() = default;
+  virtual ~ModeBase();
 
   /**
    * Register the mode. Call this once on startup, unless there's an associated executor. This is a blocking method.
@@ -199,9 +200,10 @@ private:
 
   HealthAndArmingChecks _health_and_arming_checks;
 
-  rclcpp::Subscription<px4_msgs::msg::VehicleStatus>::SharedPtr _vehicle_status_sub;
   rclcpp::Publisher<px4_msgs::msg::ModeCompleted>::SharedPtr _mode_completed_pub;
   rclcpp::Publisher<px4_msgs::msg::VehicleControlMode>::SharedPtr _config_control_setpoints_pub;
+
+  std::unique_ptr<SharedVehicleStatusToken> _vehicle_status_sub_token;
 
   bool _is_active{false};       ///< Mode is currently selected
   bool _is_armed{false};       ///< Is vehicle armed?

--- a/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
@@ -17,6 +17,7 @@
 #include <functional>
 
 class Registration;
+class SharedVehicleStatusToken;
 
 namespace px4_ros2
 {
@@ -53,7 +54,7 @@ public:
     rclcpp::Node & node, const Settings & settings, ModeBase & owned_mode,
     const std::string & topic_namespace_prefix = "");
   ModeExecutorBase(const ModeExecutorBase &) = delete;
-  virtual ~ModeExecutorBase() = default;
+  virtual ~ModeExecutorBase();
 
   /**
    * Register the mode executor. Call this once on startup. This is a blocking method.
@@ -195,8 +196,9 @@ private:
 
   std::shared_ptr<Registration> _registration;
 
-  rclcpp::Subscription<px4_msgs::msg::VehicleStatus>::SharedPtr _vehicle_status_sub;
   rclcpp::Publisher<px4_msgs::msg::VehicleCommand>::SharedPtr _vehicle_command_pub;
+
+  std::unique_ptr<SharedVehicleStatusToken> _vehicle_status_sub_token;
 
   ScheduledMode _current_scheduled_mode;
   WaitForVehicleStatusCondition _current_wait_vehicle_status;

--- a/px4_ros2_cpp/src/components/vehicle_status.cpp
+++ b/px4_ros2_cpp/src/components/vehicle_status.cpp
@@ -1,0 +1,87 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#include "vehicle_status.hpp"
+
+#include <px4_ros2/utils/message_version.hpp>
+
+std::map<SharedVehicleStatus::Key,
+  std::shared_ptr<SharedVehicleStatus>> SharedVehicleStatus::instances;
+std::mutex SharedVehicleStatus::mutex;
+
+SharedVehicleStatus & SharedVehicleStatus::instance(
+  rclcpp::Node & node,
+  const std::string & topic_namespace_prefix)
+{
+  // Maintain a single instance per node and topic namespace prefix.
+  // Even though the ROS MultiThreadedExecutor is not supported by the library, a user might still use multiple Nodes
+  // running in different threads. Therefore, we use a mutex here.
+  const std::lock_guard lg{mutex};
+  const Key key{&node, topic_namespace_prefix};
+  auto it = instances.find(key);
+  if (it != instances.end()) {
+    return *it->second;
+  }
+  const auto status =
+    std::shared_ptr<SharedVehicleStatus>(new SharedVehicleStatus(node, topic_namespace_prefix));
+  instances.emplace(key, status);
+  return *status;
+}
+
+SharedVehicleStatusToken SharedVehicleStatus::registerVehicleStatusUpdatedCallback(
+  VehicleStatusUpdatedCallback callback)
+{
+  const unsigned token = _next_token++;
+  const auto insert_ret = _vehicle_status_updated_callbacks.emplace(token, std::move(callback));
+  assert(insert_ret.second);
+  return SharedVehicleStatusToken(shared_from_this(), token);
+}
+
+SharedVehicleStatus::SharedVehicleStatus(
+  rclcpp::Node & node,
+  const std::string & topic_namespace_prefix)
+: _node(node)
+{
+  _vehicle_status_sub = _node.create_subscription<px4_msgs::msg::VehicleStatus>(
+    topic_namespace_prefix + "fmu/out/vehicle_status" +
+    px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
+      1).best_effort(),
+    [this](px4_msgs::msg::VehicleStatus::UniquePtr msg) {
+      vehicleStatusUpdated(msg);
+    });
+}
+
+void SharedVehicleStatus::unregisterVehicleStatusUpdatedCallback(unsigned token)
+{
+  const auto num_erased = _vehicle_status_updated_callbacks.erase(token);
+  assert(num_erased == 1);
+}
+
+void SharedVehicleStatus::cleanupInstanceIfUnused(
+  const std::shared_ptr<SharedVehicleStatus> & instance)
+{
+  // Remove the instance from the map if it is not used anymore.
+  // This would not strictly be required, as the static object gets destroyed at program exit. However, this causes
+  // segfaults, see https://github.com/ros2/rmw_fastrtps/pull/770 (fixed in ROS Jazzy)
+  const std::lock_guard lg{mutex};
+  if (instance->_vehicle_status_updated_callbacks.empty()) {
+    auto result = std::find_if(
+      instances.begin(), instances.end(),
+      [&instance](const auto & obj) {return obj.second == instance;});
+    if (result != instances.end()) {
+      instances.erase(result);
+    } else {
+      RCLCPP_FATAL(instance->_node.get_logger(), "Instance not found");
+    }
+  }
+}
+
+void SharedVehicleStatus::vehicleStatusUpdated(const px4_msgs::msg::VehicleStatus::UniquePtr & msg)
+const
+{
+  for (const auto & cb : _vehicle_status_updated_callbacks) {
+    cb.second(msg);
+  }
+}

--- a/px4_ros2_cpp/src/components/vehicle_status.hpp
+++ b/px4_ros2_cpp/src/components/vehicle_status.hpp
@@ -1,0 +1,105 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#pragma once
+
+#include <rclcpp/rclcpp.hpp>
+#include <px4_msgs/msg/vehicle_status.hpp>
+#include <functional>
+#include <mutex>
+#include <memory>
+
+class SharedVehicleStatusToken;
+
+/**
+ * @brief Shared class for vehicle status subscription
+ *
+ * Can be used for consistent callback ordering, by sharing a subscription instance for multiple modes.
+ */
+class SharedVehicleStatus : public std::enable_shared_from_this<SharedVehicleStatus>
+{
+public:
+  using VehicleStatusUpdatedCallback =
+    std::function<void (const px4_msgs::msg::VehicleStatus::UniquePtr &)>;
+
+  static SharedVehicleStatus & instance(
+    rclcpp::Node & node,
+    const std::string & topic_namespace_prefix = "");
+
+  [[nodiscard]] SharedVehicleStatusToken registerVehicleStatusUpdatedCallback(
+    VehicleStatusUpdatedCallback callback);
+
+  const rclcpp::Subscription<px4_msgs::msg::VehicleStatus>::SharedPtr & getSubscription() const
+  {
+    return _vehicle_status_sub;
+  }
+
+private:
+  friend class SharedVehicleStatusToken;
+
+  explicit SharedVehicleStatus(
+    rclcpp::Node & node,
+    const std::string & topic_namespace_prefix = "");
+  void unregisterVehicleStatusUpdatedCallback(unsigned token);
+  static void cleanupInstanceIfUnused(const std::shared_ptr<SharedVehicleStatus> & instance);
+
+  void vehicleStatusUpdated(const px4_msgs::msg::VehicleStatus::UniquePtr & msg) const;
+
+  rclcpp::Subscription<px4_msgs::msg::VehicleStatus>::SharedPtr _vehicle_status_sub;
+  rclcpp::Node & _node;
+  unsigned _next_token{1};
+  std::map<unsigned, VehicleStatusUpdatedCallback> _vehicle_status_updated_callbacks; // Needs guaranteed ordering
+
+  struct Key
+  {
+    rclcpp::Node * node;
+    std::string topic_namespace_prefix;
+    bool operator<(const Key & other) const
+    {
+      return node < other.node || topic_namespace_prefix < other.topic_namespace_prefix;
+    }
+  };
+
+  static std::map<Key, std::shared_ptr<SharedVehicleStatus>> instances;
+  static std::mutex mutex;
+};
+
+class SharedVehicleStatusToken
+{
+public:
+  SharedVehicleStatusToken(const SharedVehicleStatusToken & other) = delete;
+  SharedVehicleStatusToken & operator=(const SharedVehicleStatusToken & other) = delete;
+
+  SharedVehicleStatusToken(SharedVehicleStatusToken && other) noexcept
+  : _instance(std::move(other._instance)), _value(other._value)
+  {
+    other._value = std::nullopt;
+    other._instance.reset();
+  }
+  SharedVehicleStatusToken & operator=(SharedVehicleStatusToken && other) noexcept
+  {
+    if (this != &other) {
+      _value = std::move(other._value);
+      other._value = std::nullopt;
+      _instance = other._instance;
+    }
+    return *this;
+  }
+  ~SharedVehicleStatusToken()
+  {
+    const auto instance = _instance.lock();
+    if (_value.has_value() && instance) {
+      instance->unregisterVehicleStatusUpdatedCallback(*_value);
+      SharedVehicleStatus::cleanupInstanceIfUnused(instance);
+    }
+  }
+
+private:
+  SharedVehicleStatusToken(const std::shared_ptr<SharedVehicleStatus> & instance, unsigned value)
+  : _instance(instance), _value(value) {}
+  std::weak_ptr<SharedVehicleStatus> _instance;
+  std::optional<unsigned> _value;
+  friend class SharedVehicleStatus;
+};

--- a/px4_ros2_cpp/src/mission/mission_executor.cpp
+++ b/px4_ros2_cpp/src/mission/mission_executor.cpp
@@ -844,13 +844,15 @@ void MissionExecutor::abort(AbortReason reason)
     arguments["reason"] = reason_str;
     if (_state.current_index) {
       arguments["currentIndex"] = _state.current_index.value();
-      resetMissionState();
     }
     runAction(
       "onFailure", ActionArguments(arguments), [this]
       {
         RCLCPP_DEBUG(_node.get_logger(), "onFailure action completed");
         // We expect the failure action to handle everything, so do not try to do anything in addition here.
+        // We could reset the mission state here (resetMissionState()), but it might not be desired in all cases, for
+        // example when the flight controller deactivates the executor and at the same time the mission executor wants
+        // to switch modes (race condition).
       });
   }
   --_abort_recursion_level;

--- a/px4_ros2_cpp/test/unit/mission_execution.cpp
+++ b/px4_ros2_cpp/test/unit/mission_execution.cpp
@@ -1716,52 +1716,52 @@ Running action 'nonExistentAction'
 Trying to run nonexistent action 'nonExistentAction'
 Aborting mission (reason: actionDoesNotExist, recursion level: 1)
 Running action 'onFailure'
-Failure handling: recursion level: 2, reason: actionDoesNotExist, current index: -1
+Failure handling: recursion level: 2, reason: actionDoesNotExist, current index: 1
 Running action 'nonExistentAction'
 Trying to run nonexistent action 'nonExistentAction'
 Aborting mission (reason: actionDoesNotExist, recursion level: 2)
 Running action 'onFailure'
-Failure handling: recursion level: 3, reason: actionDoesNotExist, current index: -1
+Failure handling: recursion level: 3, reason: actionDoesNotExist, current index: 1
 Running action 'nonExistentAction'
 Trying to run nonexistent action 'nonExistentAction'
 Aborting mission (reason: actionDoesNotExist, recursion level: 3)
 Running action 'onFailure'
-Failure handling: recursion level: 4, reason: actionDoesNotExist, current index: -1
+Failure handling: recursion level: 4, reason: actionDoesNotExist, current index: 1
 Running action 'nonExistentAction'
 Trying to run nonexistent action 'nonExistentAction'
 Aborting mission (reason: actionDoesNotExist, recursion level: 4)
 Running action 'onFailure'
-Failure handling: recursion level: 5, reason: actionDoesNotExist, current index: -1
+Failure handling: recursion level: 5, reason: actionDoesNotExist, current index: 1
 Running action 'nonExistentAction'
 Trying to run nonexistent action 'nonExistentAction'
 Aborting mission (reason: actionDoesNotExist, recursion level: 5)
 Running action 'onFailure'
-Failure handling: recursion level: 6, reason: actionDoesNotExist, current index: -1
+Failure handling: recursion level: 6, reason: actionDoesNotExist, current index: 1
 Running action 'nonExistentAction'
 Trying to run nonexistent action 'nonExistentAction'
 Aborting mission (reason: actionDoesNotExist, recursion level: 6)
 Running action 'onFailure'
-Failure handling: recursion level: 7, reason: actionDoesNotExist, current index: -1
+Failure handling: recursion level: 7, reason: actionDoesNotExist, current index: 1
 Running action 'nonExistentAction'
 Trying to run nonexistent action 'nonExistentAction'
 Aborting mission (reason: actionDoesNotExist, recursion level: 7)
 Running action 'onFailure'
-Failure handling: recursion level: 8, reason: actionDoesNotExist, current index: -1
+Failure handling: recursion level: 8, reason: actionDoesNotExist, current index: 1
 Running action 'nonExistentAction'
 Trying to run nonexistent action 'nonExistentAction'
 Aborting mission (reason: actionDoesNotExist, recursion level: 8)
 Running action 'onFailure'
-Failure handling: recursion level: 9, reason: actionDoesNotExist, current index: -1
+Failure handling: recursion level: 9, reason: actionDoesNotExist, current index: 1
 Running action 'nonExistentAction'
 Trying to run nonexistent action 'nonExistentAction'
 Aborting mission (reason: actionDoesNotExist, recursion level: 9)
 Running action 'onFailure'
-Failure handling: recursion level: 10, reason: actionDoesNotExist, current index: -1
+Failure handling: recursion level: 10, reason: actionDoesNotExist, current index: 1
 Running action 'nonExistentAction'
 Trying to run nonexistent action 'nonExistentAction'
 Aborting mission (reason: actionDoesNotExist, recursion level: 10)
 Running action 'onFailure'
-Failure handling: recursion level: 11, reason: actionDoesNotExist, current index: -1
+Failure handling: recursion level: 11, reason: actionDoesNotExist, current index: 1
 Running action 'nonExistentAction'
 Trying to run nonexistent action 'nonExistentAction'
 Aborting mission (reason: actionDoesNotExist, recursion level: 11)

--- a/px4_ros2_cpp/test/unit/mission_execution.hpp
+++ b/px4_ros2_cpp/test/unit/mission_execution.hpp
@@ -9,9 +9,8 @@
 #include "fake_autopilot.hpp"
 #include <px4_ros2/mission/mission_executor.hpp>
 #include <px4_ros2/control/setpoint_types/goto.hpp>
+#include <px4_ros2/utils/geometry.hpp>
 #include <px4_ros2/utils/visit.hpp>
-
-#include "px4_ros2/utils/geometry.hpp"
 
 class TrajectoryExecutorTest : public px4_ros2::TrajectoryExecutorInterface
 {

--- a/px4_ros2_cpp/test/unit/modes.cpp
+++ b/px4_ros2_cpp/test/unit/modes.cpp
@@ -5,7 +5,6 @@
 
 #include <gtest/gtest.h>
 #include <rclcpp/rclcpp.hpp>
-#include <px4_ros2/components/health_and_arming_checks.hpp>
 #include <px4_ros2/components/mode.hpp>
 #include <px4_ros2/components/node_with_mode.hpp>
 #include <px4_ros2/control/setpoint_types/experimental/rates.hpp>

--- a/px4_ros2_cpp/test/unit/utils/ros_log_capture.hpp
+++ b/px4_ros2_cpp/test/unit/utils/ros_log_capture.hpp
@@ -9,6 +9,8 @@
 #include <rcl_interfaces/msg/log.hpp>
 #include <gtest/gtest.h>
 
+using namespace std::chrono_literals; // NOLINT
+
 class RosLogCapture
 {
 public:

--- a/px4_ros2_cpp/test/unit/vehicle_status.cpp
+++ b/px4_ros2_cpp/test/unit/vehicle_status.cpp
@@ -1,0 +1,173 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+#include <src/components/vehicle_status.hpp>
+#include <px4_ros2/utils/message_version.hpp>
+
+using namespace std::chrono_literals;
+
+class VehicleStatusTest : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    _node = std::make_shared<rclcpp::Node>("test_node");
+  }
+
+  bool waitForUpdate(bool & got_message)
+  {
+    got_message = false;
+    auto start_time = _node->get_clock()->now();
+    while (!got_message) {
+      rclcpp::sleep_for(kSleepInterval);
+      rclcpp::spin_some(_node);
+      const auto elapsed_time = _node->get_clock()->now() - start_time;
+      if (elapsed_time >= kTimeoutDuration) {
+        return got_message;
+      }
+    }
+    return true;
+  }
+
+  std::shared_ptr<rclcpp::Node> _node;
+
+  static constexpr std::chrono::seconds kTimeoutDuration{3s};
+  static constexpr std::chrono::milliseconds kSleepInterval{10ms};
+};
+
+
+TEST_F(VehicleStatusTest, State) {
+  // Test that registered callbacks are called in order, and removed when the token is deleted
+  SharedVehicleStatus & vehicle_status = SharedVehicleStatus::instance(*_node);
+  auto vehicle_status_pub = _node->create_publisher<px4_msgs::msg::VehicleStatus>(
+    "/fmu/out/vehicle_status" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
+      1).best_effort());
+
+  px4_msgs::msg::VehicleStatus pub_msg;
+  std::array<std::optional<SharedVehicleStatusToken>, 3> tokens;
+  std::array<unsigned, 3> message_counters{};
+
+  // Single registration
+  unsigned counter = 1;
+  bool got_message = false;
+  tokens[0] = vehicle_status.registerVehicleStatusUpdatedCallback(
+    [&](const px4_msgs::msg::VehicleStatus::UniquePtr & msg)
+    {
+      EXPECT_EQ(msg->timestamp, pub_msg.timestamp);
+      message_counters[0] = counter++;
+      got_message = true;
+    });
+
+  pub_msg.timestamp = 1;
+  vehicle_status_pub->publish(pub_msg);
+  ASSERT_TRUE(waitForUpdate(got_message));
+  EXPECT_EQ(message_counters[0], 1);
+  EXPECT_EQ(message_counters[1], 0);
+  EXPECT_EQ(message_counters[2], 0);
+
+  // Add another one
+  tokens[1] = vehicle_status.registerVehicleStatusUpdatedCallback(
+    [&](const px4_msgs::msg::VehicleStatus::UniquePtr & msg)
+    {
+      EXPECT_EQ(msg->timestamp, pub_msg.timestamp);
+      message_counters[1] = counter++;
+    });
+
+  pub_msg.timestamp++;
+  vehicle_status_pub->publish(pub_msg);
+  ASSERT_TRUE(waitForUpdate(got_message));
+  EXPECT_EQ(message_counters[0], 2);
+  EXPECT_EQ(message_counters[1], 3);
+  EXPECT_EQ(message_counters[2], 0);
+
+  // Add another one
+  tokens[2] = vehicle_status.registerVehicleStatusUpdatedCallback(
+    [&](const px4_msgs::msg::VehicleStatus::UniquePtr & msg)
+    {
+      EXPECT_EQ(msg->timestamp, pub_msg.timestamp);
+      message_counters[2] = counter++;
+    });
+
+  pub_msg.timestamp++;
+  vehicle_status_pub->publish(pub_msg);
+  ASSERT_TRUE(waitForUpdate(got_message));
+  EXPECT_EQ(message_counters[0], 4);
+  EXPECT_EQ(message_counters[1], 5);
+  EXPECT_EQ(message_counters[2], 6);
+
+  // Remove the second
+  tokens[1].reset();
+  pub_msg.timestamp++;
+  vehicle_status_pub->publish(pub_msg);
+  ASSERT_TRUE(waitForUpdate(got_message));
+  EXPECT_EQ(message_counters[0], 7);
+  EXPECT_EQ(message_counters[1], 5);
+  EXPECT_EQ(message_counters[2], 8);
+
+  // Add second again
+  tokens[1] = vehicle_status.registerVehicleStatusUpdatedCallback(
+    [&](const px4_msgs::msg::VehicleStatus::UniquePtr & msg)
+    {
+      EXPECT_EQ(msg->timestamp, pub_msg.timestamp);
+      message_counters[1] = counter++;
+    });
+
+  pub_msg.timestamp++;
+  vehicle_status_pub->publish(pub_msg);
+  ASSERT_TRUE(waitForUpdate(got_message));
+  EXPECT_EQ(message_counters[0], 9);
+  EXPECT_EQ(message_counters[1], 11);
+  EXPECT_EQ(message_counters[2], 10);
+}
+
+TEST_F(VehicleStatusTest, MultiInstance) {
+  SharedVehicleStatus & vehicle_status1 = SharedVehicleStatus::instance(*_node);
+  auto vehicle_status_pub1 = _node->create_publisher<px4_msgs::msg::VehicleStatus>(
+    "/fmu/out/vehicle_status" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
+      1).best_effort());
+
+  const std::string topic_prefix = "test/";
+  SharedVehicleStatus & vehicle_status2 = SharedVehicleStatus::instance(*_node, topic_prefix);
+  auto vehicle_status_pub2 = _node->create_publisher<px4_msgs::msg::VehicleStatus>(
+    topic_prefix + "fmu/out/vehicle_status" + px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(), rclcpp::QoS(
+      1).best_effort());
+
+  ASSERT_NE(&vehicle_status1, &vehicle_status2);
+
+  px4_msgs::msg::VehicleStatus pub_msg;
+  std::array<std::optional<SharedVehicleStatusToken>, 2> tokens;
+  std::array<unsigned, 2> message_counters{};
+
+  unsigned counter = 1;
+  bool got_message = false;
+  tokens[0] = vehicle_status1.registerVehicleStatusUpdatedCallback(
+    [&](const px4_msgs::msg::VehicleStatus::UniquePtr & msg)
+    {
+      EXPECT_EQ(msg->timestamp, pub_msg.timestamp);
+      message_counters[0] = counter++;
+      got_message = true;
+    });
+  tokens[1] = vehicle_status2.registerVehicleStatusUpdatedCallback(
+    [&](const px4_msgs::msg::VehicleStatus::UniquePtr & msg)
+    {
+      EXPECT_EQ(msg->timestamp, pub_msg.timestamp);
+      message_counters[1] = counter++;
+      got_message = true;
+    });
+
+  pub_msg.timestamp = 1;
+  vehicle_status_pub1->publish(pub_msg);
+  ASSERT_TRUE(waitForUpdate(got_message));
+  EXPECT_EQ(message_counters[0], 1);
+  EXPECT_EQ(message_counters[1], 0);
+
+  pub_msg.timestamp++;
+  vehicle_status_pub2->publish(pub_msg);
+  ASSERT_TRUE(waitForUpdate(got_message));
+  EXPECT_EQ(message_counters[0], 1);
+  EXPECT_EQ(message_counters[1], 2);
+}


### PR DESCRIPTION
This is in order to have deterministic behavior.
In particular, if there are multiple modes (with executor), the
(de)activation callback order was not determined with multiple status
subscriptions. This can be surprising and leading to different outcomes
depending on the order.
For example this happens in case there is a mission executor with a custom
mode, and the custom mode is running. When the user switches into another
mode, the deactivation of the mode and the mission are called at the same
time (with the same topic update).
This happens now in the order of how the mission executor and mode are
instantiated on startup.


This also includes a small change to the mission: the mission state is now not reset anymore on abort/failure.