### PR TITLE
mode_executor: remove node and topic namespace prefix constructor args

### DIFF
--- a/examples/cpp/modes/executor_with_multiple_modes/include/executor.hpp
+++ b/examples/cpp/modes/executor_with_multiple_modes/include/executor.hpp
@@ -11,10 +11,10 @@ class ModeExecutorTest : public px4_ros2::ModeExecutorBase
 {
 public:
   ModeExecutorTest(
-    rclcpp::Node & node, px4_ros2::ModeBase & owned_mode,
+    px4_ros2::ModeBase & owned_mode,
     px4_ros2::ModeBase & second_mode, px4_ros2::ModeBase & third_mode)
-  : ModeExecutorBase(node, px4_ros2::ModeExecutorBase::Settings{}, owned_mode),
-    _node(node), _second_mode(second_mode), _third_mode(third_mode)
+  : ModeExecutorBase(px4_ros2::ModeExecutorBase::Settings{}, owned_mode),
+    _node(owned_mode.node()), _second_mode(second_mode), _third_mode(third_mode)
   {
   }
 

--- a/examples/cpp/modes/mode_with_executor/include/mode.hpp
+++ b/examples/cpp/modes/mode_with_executor/include/mode.hpp
@@ -57,9 +57,9 @@ private:
 class ModeExecutorTest : public px4_ros2::ModeExecutorBase
 {
 public:
-  ModeExecutorTest(rclcpp::Node & node, px4_ros2::ModeBase & owned_mode)
-  : ModeExecutorBase(node, px4_ros2::ModeExecutorBase::Settings{}, owned_mode),
-    _node(node)
+  explicit ModeExecutorTest(px4_ros2::ModeBase & owned_mode)
+  : ModeExecutorBase(px4_ros2::ModeExecutorBase::Settings{}, owned_mode),
+    _node(owned_mode.node())
   {
   }
 

--- a/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode_executor.hpp
@@ -50,9 +50,7 @@ public:
     Other
   };
 
-  ModeExecutorBase(
-    rclcpp::Node & node, const Settings & settings, ModeBase & owned_mode,
-    const std::string & topic_namespace_prefix = "");
+  ModeExecutorBase(const Settings & settings, ModeBase & owned_mode);
   ModeExecutorBase(const ModeExecutorBase &) = delete;
   virtual ~ModeExecutorBase();
 

--- a/px4_ros2_cpp/include/px4_ros2/components/node_with_mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/node_with_mode.hpp
@@ -140,9 +140,9 @@ private:
   auto createModeExecutor(std::index_sequence<Idx...>)
   {
     if constexpr (sizeof...(Idx) == 0) {
-      return std::make_unique<ModeExecutorT>(*this, *_owned_mode);
+      return std::make_unique<ModeExecutorT>(*_owned_mode);
     } else {
-      return std::make_unique<ModeExecutorT>(*this, *_owned_mode, *std::get<Idx>(_other_modes)...);
+      return std::make_unique<ModeExecutorT>(*_owned_mode, *std::get<Idx>(_other_modes)...);
     }
   }
 

--- a/px4_ros2_cpp/include/px4_ros2/mission/mission_executor.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/mission/mission_executor.hpp
@@ -154,7 +154,7 @@ public:
     MissionModeExecutor(
       rclcpp::Node & node, const Settings & settings, ModeBase & owned_mode,
       const std::string & topic_namespace_prefix, MissionExecutor & mission_executor)
-    : ModeExecutorBase(node, settings, owned_mode, topic_namespace_prefix), _mission_executor(
+    : ModeExecutorBase(settings, owned_mode), _mission_executor(
         mission_executor)
     {
     }

--- a/px4_ros2_cpp/test/integration/mode_executor.cpp
+++ b/px4_ros2_cpp/test/integration/mode_executor.cpp
@@ -80,7 +80,7 @@ class ModeExecutorTest : public px4_ros2::ModeExecutorBase
 {
 public:
   ModeExecutorTest(rclcpp::Node & node, FlightModeTest & owned_mode, bool activate_immediately)
-  : ModeExecutorBase(node,
+  : ModeExecutorBase(
       ModeExecutorBase::Settings{activate_immediately ? Settings::Activation::ActivateImmediately :
         Settings::Activation::ActivateOnlyWhenArmed},
       owned_mode),

--- a/px4_ros2_cpp/test/integration/overrides.cpp
+++ b/px4_ros2_cpp/test/integration/overrides.cpp
@@ -79,7 +79,7 @@ class ModeExecutorTest : public px4_ros2::ModeExecutorBase
 {
 public:
   ModeExecutorTest(rclcpp::Node & node, FlightModeTest & owned_mode, bool activate_immediately)
-  : ModeExecutorBase(node,
+  : ModeExecutorBase(
       ModeExecutorBase::Settings{activate_immediately ? Settings::Activation::ActivateImmediately :
         Settings::Activation::ActivateOnlyWhenArmed},
       owned_mode),


### PR DESCRIPTION
These can be accessed from the mode and need to be the same anyway