### PR TITLE
Expose throttle direct for FwLateralLongitudinal Setpoint

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/fixedwing/lateral_longitudinal.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/fixedwing/lateral_longitudinal.hpp
@@ -119,6 +119,7 @@ struct FwLateralLongitudinalSetpoint
   std::optional<float> altitude_msl;
   std::optional<float> height_rate;
   std::optional<float> equivalent_airspeed;
+  std::optional<float> throttle_direct;
 
   FwLateralLongitudinalSetpoint & withCourse(float course_sp)
   {
@@ -153,6 +154,13 @@ struct FwLateralLongitudinalSetpoint
   FwLateralLongitudinalSetpoint & withEquivalentAirspeed(float equivalent_airspeed_sp)
   {
     equivalent_airspeed = equivalent_airspeed_sp;
+    return *this;
+  }
+
+  FwLateralLongitudinalSetpoint & withThrottleDirect(float throttle_direct_sp)
+  {
+
+    throttle_direct = throttle_direct_sp;
     return *this;
   }
 };

--- a/px4_ros2_cpp/src/control/setpoint_types/fixedwing/lateral_longitudinal.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/fixedwing/lateral_longitudinal.cpp
@@ -122,7 +122,7 @@ void FwLateralLongitudinalSetpointType::update(const FwLateralLongitudinalSetpoi
   longitudinal_sp.height_rate = setpoint.height_rate.value_or(NAN);
   longitudinal_sp.equivalent_airspeed = setpoint.equivalent_airspeed.value_or(NAN);
   longitudinal_sp.pitch_direct = NAN;
-  longitudinal_sp.throttle_direct = NAN;
+  longitudinal_sp.throttle_direct = setpoint.throttle_direct.value_or(NAN);
 
   _fw_longitudinal_sp_pub->publish(longitudinal_sp);
 }


### PR DESCRIPTION
**Problem Description**
When conducting fixed-wing vehicle performance estimation, one would measure the sink rate of the vehicle at different airspeed setpoints and throttle settings. However, the `FWLateralLongitudinalSetpoint` does not expose the throttle_direct even though the underlying setpoint message has a field for throttle_direct.

**Solution**
This PR exposes throttle_direct for the FWLateralLongitudinalSetpoint. 

Tested in SITL. Sending an airspeed setpoint and fixed throttle results in a stable sinkrate.
- Log: https://review.px4.io/plot_app?log=f0dac6f3-7f8d-49a2-860b-cb2c282820f5

**Additional Context**
- This PR is implemented on top of https://github.com/Auterion/px4-ros2-interface-lib/pull/154