### PR TITLE
Fix: Align VehicleRatesSetpoint variable naming with FRD body frame

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/rates.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/experimental/rates.hpp
@@ -30,7 +30,7 @@ public:
   float desiredUpdateRateHz() override {return 200.f;}
 
   void update(
-    const Eigen::Vector3f & rate_setpoints_ned_rad,
+    const Eigen::Vector3f & rate_setpoints_frd_rad,
     const Eigen::Vector3f & thrust_setpoint_frd);
 
 private:

--- a/px4_ros2_cpp/src/control/setpoint_types/experimental/rates.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/experimental/rates.cpp
@@ -20,15 +20,15 @@ RatesSetpointType::RatesSetpointType(Context & context)
 }
 
 void RatesSetpointType::update(
-  const Eigen::Vector3f & rate_setpoints_ned_rad,
+  const Eigen::Vector3f & rate_setpoints_frd_rad,
   const Eigen::Vector3f & thrust_setpoint_frd)
 {
   onUpdate();
 
   px4_msgs::msg::VehicleRatesSetpoint sp{};
-  sp.roll = rate_setpoints_ned_rad(0);
-  sp.pitch = rate_setpoints_ned_rad(1);
-  sp.yaw = rate_setpoints_ned_rad(2);
+  sp.roll = rate_setpoints_frd_rad(0);
+  sp.pitch = rate_setpoints_frd_rad(1);
+  sp.yaw = rate_setpoints_frd_rad(2);
   sp.thrust_body[0] = thrust_setpoint_frd(0);
   sp.thrust_body[1] = thrust_setpoint_frd(1);
   sp.thrust_body[2] = thrust_setpoint_frd(2);


### PR DESCRIPTION
### Summary 
Fix #158 
This Pull Request addresses the variable naming inconsistency where the local angular rate setpoint was labeled with the **NED (North-East-Down)** convention, despite the corresponding PX4 message explicitly using the **FRD (Forward-Right-Down) body frame**.

The variable has been renamed from `rate_setpoints_ned_rad` to **`rate_setpoints_frd_rad`** to ensure consistency.

### Context and Rationale 

The official PX4 message definition for the rates clearly states that the values are in the **FRD body frame**:

> `px4_msgs/VehicleRatesSetpoint.msg`: `# body angular rates in FRD frame`
> *Source:* [PX4/px4_msgs/VehicleRatesSetpoint.msg#L5](https://github.com/PX4/px4_msgs/blob/49a0f6c52cf86948e46e5df8a7b61e33319c9ed2/msg/VehicleRatesSetpoint.msg#L5)

Using `NED` (a World/Inertial Frame) to label data that belongs to the **Body-Fixed Frame (FRD)** is misleading. This change improves code clarity and aligns the implementation with the message definition, reducing the risk of coordinate system misinterpretation.

### Changes 

- Renamed the variable `rate_setpoints_ned_rad` to **`rate_setpoints_frd_rad`** in `px4_ros2_cpp/src/control/setpoint_types/experimental/rates.cpp`.
