### PR TITLE
Simplify attitude conversion between ENU and NED

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/utils/frame_conversion.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/frame_conversion.hpp
@@ -32,9 +32,9 @@ Eigen::Quaternion<Type> attitudeNedToEnu(const Eigen::Quaternion<Type> & q_ned)
 {
   static constexpr Type kHalfSqrt2 = static_cast<Type>(0.7071067811865476);
   const Eigen::Quaternion<Type> q_ned_to_enu {0.0, kHalfSqrt2, kHalfSqrt2, 0.0};  // 180 deg along X, -90 deg along Z (intrinsic)
-  const Eigen::Quaternion<Type> q_yaw_minus_pi_2{kHalfSqrt2, 0.0, 0.0, -kHalfSqrt2};  // -90 deg along Z
+  const Eigen::Quaternion<Type> q_flu_to_frd{0.0, 1.0, 0.0, 0.0};  // 180 deg along X
 
-  return q_ned_to_enu * q_ned * q_yaw_minus_pi_2 * q_ned_to_enu.inverse();
+  return q_ned_to_enu * q_ned * q_flu_to_frd;
 }
 
 /**
@@ -49,9 +49,9 @@ Eigen::Quaternion<Type> attitudeEnuToNed(const Eigen::Quaternion<Type> & q_enu)
 {
   static constexpr Type kHalfSqrt2 = static_cast<Type>(0.7071067811865476);
   const Eigen::Quaternion<Type> q_enu_to_ned {0.0, kHalfSqrt2, kHalfSqrt2, 0.0};  // 180 deg along X, -90 deg along Z (intrinsic)
-  const Eigen::Quaternion<Type> q_yaw_minus_pi_2{kHalfSqrt2, 0.0, 0.0, -kHalfSqrt2};  // -90 deg along Z
+  const Eigen::Quaternion<Type> q_frd_to_flu{0.0, 1.0, 0.0, 0.0};  // 180 deg along X
 
-  return q_enu_to_ned * q_enu * q_yaw_minus_pi_2 * q_enu_to_ned.inverse();
+  return q_enu_to_ned * q_enu * q_frd_to_flu;
 }
 
 /**


### PR DESCRIPTION
Proof: https://colab.research.google.com/drive/1NAEfr1jUaM0qwsxNd6ZNhhr0siUl_bGV?usp=sharing

yaw -90, followed by yaw +90 and roll -180 is the same as roll +180. Also, there is no reason to re-use the conversion between NED and ENU to rotate between FRD and FLU  