### PR TITLE
fix: use create_timer for sim-coupled timing

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/mission/actions/default_actions.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/mission/actions/default_actions.hpp
@@ -90,12 +90,12 @@ class Hold : public ActionInterface {
       duration_s = arguments.at<float>("duration");
     }
     handler->runMode(ModeBase::kModeIDLoiter, [] {});
-    // Use create_timer (node clock) so "hold N seconds" means N sim seconds in simulation.
-    _timer =
-        _node.create_timer(std::chrono::duration<float>(duration_s), [this, on_completed] {
-          _timer.reset();
-          on_completed();
-        });
+    // Use node clock for sim time support
+    _timer = rclcpp::create_timer(&_node, _node.get_clock(),
+                                  rclcpp::Duration::from_seconds(duration_s), [this, on_completed] {
+                                    _timer.reset();
+                                    on_completed();
+                                  });
   }
 
   void deactivate() override { _timer.reset(); }

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -141,12 +141,10 @@ void ModeBase::updateSetpointUpdateTimer()
 
   if (activate) {
     if (!_setpoint_update_timer) {
-      // Use create_timer (node clock) so the loop fires at the intended rate in sim time.
-      // create_wall_timer would fire at wall-clock rate, causing integrator wind-up when
-      // sim runs slower than real time (e.g. 0.5x → 2× updates per sim second).
-      _setpoint_update_timer = node().create_timer(
-          std::chrono::milliseconds(static_cast<int64_t>(1000.f / _setpoint_update_rate_hz)),
-          [this]() {
+      // Use node clock for sim time support
+      _setpoint_update_timer = rclcpp::create_timer(
+          &node(), node().get_clock(),
+          rclcpp::Duration::from_seconds(1.0 / _setpoint_update_rate_hz), [this]() {
             const auto now = node().get_clock()->now();
             const float dt_s = (now - _last_setpoint_update).seconds();
             _last_setpoint_update = now;


### PR DESCRIPTION
## Summary
Use `create_timer` instead of `create_wall_timer` for sim-coupled timing so control and mission logic run at the intended rate in simulation.

## Problem
While testing in simulation running slower than real time, we saw unstable behavior. The mode’s control loop used create_wall_timer, so when sim ran slower than real time the loop fired too often per sim second, causing integrator wind-up and incorrect thrust.

## Solution
- **mode.cpp**: Setpoint update timer now uses `create_timer` (node clock) so the loop runs at the intended rate in sim time.
- **default_actions Hold**: "Hold N seconds" now uses N sim seconds instead of N wall seconds.
