### PR TITLE
fix(vtol): make status staleness timeout configurable (default 5s)

### DIFF
--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -225,6 +225,7 @@ if(BUILD_TESTING)
             test/unit/mission_execution.cpp
             test/unit/modes.cpp
             test/unit/shared_subscription.cpp
+            test/unit/vtol.cpp
             test/unit/utils/frame_conversion.cpp
             test/unit/utils/geodesic.cpp
             test/unit/utils/geometry.cpp

--- a/px4_ros2_cpp/include/px4_ros2/control/vtol.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/vtol.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <chrono>
+
 #include <Eigen/Core>
 #include <px4_msgs/msg/vehicle_command.hpp>
 #include <px4_msgs/msg/vehicle_local_position.hpp>
@@ -19,6 +21,8 @@ struct VTOLConfig {
   float back_transition_deceleration_setpoint_to_pitch_i{
       0.1f}; /**< Backtransition deceleration setpoint to pitch I gain  [rad s/m]. */
   float deceleration_integrator_limit{0.3f};
+  std::chrono::seconds status_timeout{
+      5}; /**< Maximum age of VtolVehicleStatus before state is considered unknown [s]. */
 
   VTOLConfig& withBackTransitionDeceleration(const float back_transition_deceleration)
   {
@@ -37,6 +41,12 @@ struct VTOLConfig {
   {
     this->back_transition_deceleration_setpoint_to_pitch_i =
         back_transition_deceleration_setpoint_to_pitch_i;
+    return *this;
+  }
+
+  VTOLConfig& withStatusTimeout(const std::chrono::seconds timeout)
+  {
+    this->status_timeout = timeout;
     return *this;
   }
 };
@@ -78,7 +88,7 @@ class VTOL {
   rclcpp::Subscription<px4_msgs::msg::VtolVehicleStatus>::SharedPtr _vtol_vehicle_status_sub;
   SharedSubscriptionCallbackInstance _vehicle_local_position_cb;
   rclcpp::Time _last_command_sent;
-  rclcpp::Time _last_vtol_vehicle_status_received;
+  rclcpp::Time _last_vtol_vehicle_status_received{0, 0, _node.get_clock()->get_clock_type()};
   rclcpp::Time _last_pitch_integrator_update{0, 0, _node.get_clock()->get_clock_type()};
 
   float _vehicle_heading{NAN};

--- a/px4_ros2_cpp/include/px4_ros2/control/vtol.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/vtol.hpp
@@ -5,9 +5,8 @@
 
 #pragma once
 
-#include <chrono>
-
 #include <Eigen/Core>
+#include <chrono>
 #include <px4_msgs/msg/vehicle_command.hpp>
 #include <px4_msgs/msg/vehicle_local_position.hpp>
 #include <px4_msgs/msg/vtol_vehicle_status.hpp>

--- a/px4_ros2_cpp/src/control/vtol.cpp
+++ b/px4_ros2_cpp/src/control/vtol.cpp
@@ -61,7 +61,7 @@ bool VTOL::toMulticopter()
 {
   const auto now = _node.get_clock()->now();
 
-  if (now - _last_vtol_vehicle_status_received < 2s) {
+  if (now - _last_vtol_vehicle_status_received < _config.status_timeout) {
     if ((_current_state == VTOL::State::FixedWing ||
          _current_state == VTOL::State::TransitionToFixedWing) &&
         (now - _last_command_sent) > 150ms) {
@@ -90,7 +90,7 @@ bool VTOL::toFixedwing()
 {
   const auto now = _node.get_clock()->now();
 
-  if (now - _last_vtol_vehicle_status_received < 2s) {
+  if (now - _last_vtol_vehicle_status_received < _config.status_timeout) {
     if ((_current_state == VTOL::State::Multicopter ||
          _current_state == VTOL::State::TransitionToMulticopter) &&
         (now - _last_command_sent) > 150ms) {

--- a/px4_ros2_cpp/test/unit/vtol.cpp
+++ b/px4_ros2_cpp/test/unit/vtol.cpp
@@ -135,16 +135,14 @@ TEST_F(VTOLTest, StateTransitions)
   px4_ros2::Context context(*_node);
   px4_ros2::VTOL vtol(context);
 
-  ASSERT_TRUE(
-      publishVtolStatus(vtol, px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_MC));
+  ASSERT_TRUE(publishVtolStatus(vtol, px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_MC));
   EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::Multicopter);
 
   ASSERT_TRUE(publishVtolStatus(
       vtol, px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_TRANSITION_TO_FW));
   EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::TransitionToFixedWing);
 
-  ASSERT_TRUE(
-      publishVtolStatus(vtol, px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_FW));
+  ASSERT_TRUE(publishVtolStatus(vtol, px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_FW));
   EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::FixedWing);
 
   ASSERT_TRUE(publishVtolStatus(

--- a/px4_ros2_cpp/test/unit/vtol.cpp
+++ b/px4_ros2_cpp/test/unit/vtol.cpp
@@ -7,6 +7,7 @@
 
 #include <px4_ros2/control/vtol.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <thread>
 
 using namespace std::chrono_literals;
 
@@ -18,18 +19,41 @@ class VTOLTest : public testing::Test {
     _executor.add_node(_node);
   }
 
-  void publishVtolStatus(uint8_t state)
+  bool publishVtolStatus(px4_ros2::VTOL& vtol, uint8_t state)
   {
     auto pub = _node->create_publisher<px4_msgs::msg::VtolVehicleStatus>(
         "fmu/out/vtol_vehicle_status", rclcpp::QoS(10).best_effort());
     px4_msgs::msg::VtolVehicleStatus msg;
     msg.vehicle_vtol_state = state;
     pub->publish(msg);
-    // Spin to deliver the message
-    rclcpp::sleep_for(50ms);
-    _executor.spin_some();
-    rclcpp::sleep_for(50ms);
-    _executor.spin_some();
+
+    // Poll until subscription delivers the message (or timeout)
+    const auto expected = toExpectedState(state);
+    const auto start = _node->get_clock()->now();
+    while (_node->get_clock()->now() - start < 3s) {
+      _executor.spin_some();
+      if (vtol.getCurrentState() == expected) {
+        return true;
+      }
+      std::this_thread::yield();
+    }
+    return false;
+  }
+
+  static px4_ros2::VTOL::State toExpectedState(uint8_t state)
+  {
+    switch (state) {
+      case px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_MC:
+        return px4_ros2::VTOL::State::Multicopter;
+      case px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_FW:
+        return px4_ros2::VTOL::State::FixedWing;
+      case px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_TRANSITION_TO_FW:
+        return px4_ros2::VTOL::State::TransitionToFixedWing;
+      case px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_TRANSITION_TO_MC:
+        return px4_ros2::VTOL::State::TransitionToMulticopter;
+      default:
+        return px4_ros2::VTOL::State::Undefined;
+    }
   }
 
   std::shared_ptr<rclcpp::Node> _node;
@@ -89,7 +113,7 @@ TEST_F(VTOLTest, TransitionSucceedsWithFreshStatus)
   px4_ros2::VTOL vtol(context);
 
   // Publish a FixedWing status so toMulticopter() has valid state
-  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_FW);
+  ASSERT_TRUE(publishVtolStatus(vtol, px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_FW));
 
   EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::FixedWing);
   EXPECT_TRUE(vtol.toMulticopter());
@@ -100,7 +124,7 @@ TEST_F(VTOLTest, ToFixedwingSucceedsFromMulticopter)
   px4_ros2::Context context(*_node);
   px4_ros2::VTOL vtol(context);
 
-  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_MC);
+  ASSERT_TRUE(publishVtolStatus(vtol, px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_MC));
 
   EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::Multicopter);
   EXPECT_TRUE(vtol.toFixedwing());
@@ -111,16 +135,20 @@ TEST_F(VTOLTest, StateTransitions)
   px4_ros2::Context context(*_node);
   px4_ros2::VTOL vtol(context);
 
-  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_MC);
+  ASSERT_TRUE(
+      publishVtolStatus(vtol, px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_MC));
   EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::Multicopter);
 
-  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_TRANSITION_TO_FW);
+  ASSERT_TRUE(publishVtolStatus(
+      vtol, px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_TRANSITION_TO_FW));
   EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::TransitionToFixedWing);
 
-  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_FW);
+  ASSERT_TRUE(
+      publishVtolStatus(vtol, px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_FW));
   EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::FixedWing);
 
-  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_TRANSITION_TO_MC);
+  ASSERT_TRUE(publishVtolStatus(
+      vtol, px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_TRANSITION_TO_MC));
   EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::TransitionToMulticopter);
 }
 
@@ -131,7 +159,7 @@ TEST_F(VTOLTest, CustomTimeoutIsUsed)
   auto config = px4_ros2::VTOLConfig{}.withStatusTimeout(std::chrono::seconds(1));
   px4_ros2::VTOL vtol(context, config);
 
-  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_FW);
+  ASSERT_TRUE(publishVtolStatus(vtol, px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_FW));
   EXPECT_TRUE(vtol.toMulticopter());
 
   // Wait for the short timeout to expire

--- a/px4_ros2_cpp/test/unit/vtol.cpp
+++ b/px4_ros2_cpp/test/unit/vtol.cpp
@@ -1,0 +1,140 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <px4_ros2/control/vtol.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+using namespace std::chrono_literals;
+
+class VTOLTest : public testing::Test {
+ protected:
+  void SetUp() override
+  {
+    _node = std::make_shared<rclcpp::Node>("vtol_test_node");
+    _executor.add_node(_node);
+  }
+
+  void publishVtolStatus(uint8_t state)
+  {
+    auto pub = _node->create_publisher<px4_msgs::msg::VtolVehicleStatus>(
+        "fmu/out/vtol_vehicle_status", rclcpp::QoS(10).best_effort());
+    px4_msgs::msg::VtolVehicleStatus msg;
+    msg.vehicle_vtol_state = state;
+    pub->publish(msg);
+    // Spin to deliver the message
+    rclcpp::sleep_for(50ms);
+    _executor.spin_some();
+    rclcpp::sleep_for(50ms);
+    _executor.spin_some();
+  }
+
+  std::shared_ptr<rclcpp::Node> _node;
+  rclcpp::executors::SingleThreadedExecutor _executor;
+};
+
+// --- VTOLConfig tests ---
+
+TEST(VTOLConfig, DefaultValues)
+{
+  px4_ros2::VTOLConfig config;
+  EXPECT_FLOAT_EQ(config.back_transition_deceleration, 2.f);
+  EXPECT_FLOAT_EQ(config.back_transition_deceleration_setpoint_to_pitch_i, 0.1f);
+  EXPECT_FLOAT_EQ(config.deceleration_integrator_limit, 0.3f);
+  EXPECT_EQ(config.status_timeout, std::chrono::seconds(5));
+}
+
+TEST(VTOLConfig, WithStatusTimeout)
+{
+  auto config = px4_ros2::VTOLConfig{}.withStatusTimeout(std::chrono::seconds(10));
+  EXPECT_EQ(config.status_timeout, std::chrono::seconds(10));
+}
+
+TEST(VTOLConfig, BuilderChaining)
+{
+  auto config = px4_ros2::VTOLConfig{}
+                    .withBackTransitionDeceleration(3.f)
+                    .withStatusTimeout(std::chrono::seconds(8))
+                    .withDecelerationIntegratorLimit(0.5f);
+  EXPECT_FLOAT_EQ(config.back_transition_deceleration, 3.f);
+  EXPECT_FLOAT_EQ(config.deceleration_integrator_limit, 0.5f);
+  EXPECT_EQ(config.status_timeout, std::chrono::seconds(8));
+}
+
+// --- VTOL transition tests ---
+
+TEST_F(VTOLTest, InitialStateUndefined)
+{
+  px4_ros2::Context context(*_node);
+  px4_ros2::VTOL vtol(context);
+  EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::Undefined);
+}
+
+TEST_F(VTOLTest, TransitionFailsWithoutStatus)
+{
+  px4_ros2::Context context(*_node);
+  px4_ros2::VTOL vtol(context);
+
+  // No VtolVehicleStatus received yet — transitions should fail
+  EXPECT_FALSE(vtol.toMulticopter());
+  EXPECT_FALSE(vtol.toFixedwing());
+}
+
+TEST_F(VTOLTest, TransitionSucceedsWithFreshStatus)
+{
+  px4_ros2::Context context(*_node);
+  px4_ros2::VTOL vtol(context);
+
+  // Publish a FixedWing status so toMulticopter() has valid state
+  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_FW);
+
+  EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::FixedWing);
+  EXPECT_TRUE(vtol.toMulticopter());
+}
+
+TEST_F(VTOLTest, ToFixedwingSucceedsFromMulticopter)
+{
+  px4_ros2::Context context(*_node);
+  px4_ros2::VTOL vtol(context);
+
+  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_MC);
+
+  EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::Multicopter);
+  EXPECT_TRUE(vtol.toFixedwing());
+}
+
+TEST_F(VTOLTest, StateTransitions)
+{
+  px4_ros2::Context context(*_node);
+  px4_ros2::VTOL vtol(context);
+
+  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_MC);
+  EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::Multicopter);
+
+  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_TRANSITION_TO_FW);
+  EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::TransitionToFixedWing);
+
+  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_FW);
+  EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::FixedWing);
+
+  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_TRANSITION_TO_MC);
+  EXPECT_EQ(vtol.getCurrentState(), px4_ros2::VTOL::State::TransitionToMulticopter);
+}
+
+TEST_F(VTOLTest, CustomTimeoutIsUsed)
+{
+  // Use a very short timeout (1s) to verify it's configurable
+  px4_ros2::Context context(*_node);
+  auto config = px4_ros2::VTOLConfig{}.withStatusTimeout(std::chrono::seconds(1));
+  px4_ros2::VTOL vtol(context, config);
+
+  publishVtolStatus(px4_msgs::msg::VtolVehicleStatus::VEHICLE_VTOL_STATE_FW);
+  EXPECT_TRUE(vtol.toMulticopter());
+
+  // Wait for the short timeout to expire
+  rclcpp::sleep_for(1100ms);
+  EXPECT_FALSE(vtol.toMulticopter());
+}


### PR DESCRIPTION
## Summary

- Replace hardcoded 2s `VtolVehicleStatus` staleness timeout with configurable `status_timeout` in `VTOLConfig` (default: 5s)
- Fix uninitialized `_last_vtol_vehicle_status_received` clock type causing exception when calling `toMulticopter()`/`toFixedwing()` before receiving any status message
- Add unit tests for `VTOLConfig` and `VTOL` transition behavior

## Problem

**Timeout too tight:** PX4's `vtol_att_control` publishes `VtolVehicleStatus` at a minimum rate of 1 Hz (only faster on state changes). The hardcoded 2s staleness window tolerates only one missed message before silently refusing transition commands. Under real-world conditions (SITL CPU contention, DDS jitter, Gazebo rendering load), this causes intermittent transition failures.

**Clock mismatch crash:** `_last_vtol_vehicle_status_received` was default-constructed without a clock type, while `toMulticopter()`/`toFixedwing()` compare it against `_node.get_clock()->now()`. If called before any `VtolVehicleStatus` is received, this throws `"can't subtract times with different time sources"` instead of returning `false`.

## Changes

**`vtol.hpp`:**
- Add `std::chrono::seconds status_timeout{5}` to `VTOLConfig` with `withStatusTimeout()` builder
- Initialize `_last_vtol_vehicle_status_received` with `_node.get_clock()->get_clock_type()` (matching the existing pattern for `_last_pitch_integrator_update`)

**`vtol.cpp`:**
- Replace `< 2s` with `< _config.status_timeout` in both `toMulticopter()` and `toFixedwing()`

**`test/unit/vtol.cpp`:** (new)
- `VTOLConfig.DefaultValues` — verify all defaults including `status_timeout`
- `VTOLConfig.WithStatusTimeout` — builder pattern
- `VTOLConfig.BuilderChaining` — chaining multiple builders
- `VTOLTest.InitialStateUndefined` — initial state is `Undefined`
- `VTOLTest.TransitionFailsWithoutStatus` — returns `false` before any status received (previously crashed)
- `VTOLTest.TransitionSucceedsWithFreshStatus` — works after receiving status
- `VTOLTest.ToFixedwingSucceedsFromMulticopter` — MC→FW transition
- `VTOLTest.StateTransitions` — all 4 state transitions via published messages
- `VTOLTest.CustomTimeoutIsUsed` — verifies configurable timeout works (1s timeout, wait 1.1s, transition fails)

## Why 5s default

- 1 Hz publication rate → messages every ~1s
- 5s allows up to 4 missed heartbeats before considering state unknown
- Still detects genuinely dead connections within a reasonable window
- Configurable for tighter or looser bounds via `VTOLConfig{}.withStatusTimeout(...)`

## Test results

```
[==========] 76 tests from 14 test suites ran. (7009 ms total)
[  PASSED  ] 76 tests.
Summary: 77 tests, 0 errors, 0 failures, 0 skipped
```

Fixes #185