### PR TITLE
fix(geodesic): add topic namespace prefix to MapProjection

### DIFF
--- a/px4_ros2_cpp/src/utils/geodesic.cpp
+++ b/px4_ros2_cpp/src/utils/geodesic.cpp
@@ -17,7 +17,7 @@ MapProjection::MapProjection(Context& context) : _node(context.node())
   // Use a shared subscription instance as this is a higher-rate topic
   _vehicle_local_position_cb = SharedSubscription<px4_msgs::msg::VehicleLocalPosition>::create(
       _node,
-      "fmu/out/vehicle_local_position" +
+      context.topicNamespacePrefix() + "fmu/out/vehicle_local_position" +
           px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleLocalPosition>(),
       [this](const px4_msgs::msg::VehicleLocalPosition::UniquePtr& msg) {
         vehicleLocalPositionCallback(msg);


### PR DESCRIPTION
## Summary
MapProjection subscribes to `fmu/out/vehicle_local_position` without prepending `context.topicNamespacePrefix()`, breaking multi-vehicle setups and namespaced deployments.

All other classes (VTOL, GlobalPosition, etc.) correctly use the prefix. This one-line fix aligns MapProjection with that pattern.

Fixes #152

## Test plan
- [x] Code review: single-line change adding `context.topicNamespacePrefix() +` to the topic string
- [x] Verified all other SharedSubscription usages in the codebase use the prefix