### PR TITLE
feat(vehicle_state): add HomePositionSetter utility

### DIFF
--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -207,6 +207,7 @@ if(BUILD_TESTING)
             test/integration/mode.cpp
             test/integration/mission.cpp
             test/integration/mode_executor.cpp
+            test/integration/home_position_setter.cpp
             test/integration/overrides.cpp
     )
     if(TARGET integration_tests)
@@ -229,6 +230,7 @@ if(BUILD_TESTING)
             test/unit/mission_execution.cpp
             test/unit/modes.cpp
             test/unit/shared_subscription.cpp
+            test/unit/vehicle_command_sender.cpp
             test/unit/utils/frame_conversion.cpp
             test/unit/utils/geodesic.cpp
             test/unit/utils/geometry.cpp

--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -112,6 +112,7 @@ set(HEADER_FILES
         include/px4_ros2/utils/visit.hpp
         include/px4_ros2/vehicle_state/battery.hpp
         include/px4_ros2/vehicle_state/home_position.hpp
+        include/px4_ros2/vehicle_state/home_position_setter.hpp
         include/px4_ros2/vehicle_state/land_detected.hpp
         include/px4_ros2/vehicle_state/vehicle_status.hpp
         include/px4_ros2/vehicle_state/vtol_status.hpp
@@ -156,6 +157,7 @@ add_library(px4_ros2_cpp
         src/odometry/attitude.cpp
         src/odometry/global_position.cpp
         src/odometry/local_position.cpp
+        src/vehicle_state/home_position_setter.cpp
         src/utils/geodesic.cpp
         src/utils/map_projection_impl.cpp
 )

--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -109,6 +109,7 @@ set(HEADER_FILES
         include/px4_ros2/utils/geodesic.hpp
         include/px4_ros2/utils/geometry.hpp
         include/px4_ros2/utils/message_version.hpp
+        include/px4_ros2/utils/vehicle_command_sender.hpp
         include/px4_ros2/utils/visit.hpp
         include/px4_ros2/vehicle_state/battery.hpp
         include/px4_ros2/vehicle_state/home_position.hpp
@@ -158,6 +159,7 @@ add_library(px4_ros2_cpp
         src/odometry/global_position.cpp
         src/odometry/local_position.cpp
         src/vehicle_state/home_position_setter.cpp
+        src/utils/vehicle_command_sender.cpp
         src/utils/geodesic.cpp
         src/utils/map_projection_impl.cpp
 )

--- a/px4_ros2_cpp/include/px4_ros2/utils/vehicle_command_sender.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/vehicle_command_sender.hpp
@@ -1,0 +1,56 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#pragma once
+
+#include <px4_msgs/msg/vehicle_command.hpp>
+#include <px4_msgs/msg/vehicle_command_ack.hpp>
+#include <px4_ros2/components/mode.hpp>
+#include <px4_ros2/utils/message_version.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <string>
+
+namespace px4_ros2 {
+/** \ingroup utils
+ *  @{
+ */
+
+/**
+ * @brief Sends a VehicleCommand and waits synchronously for an ACK from PX4.
+ *
+ * This helper can be reused by any component that needs to send one-shot
+ * vehicle commands with acknowledgement (e.g. HomePositionSetter,
+ * ModeExecutorBase).
+ */
+class VehicleCommandSender {
+ public:
+  /**
+   * @param node          ROS 2 node used for creating publishers/subscriptions
+   * @param topic_namespace_prefix  topic namespace (e.g. "" or "/my_ns/")
+   * @param command_topic command topic name without prefix/version suffix
+   *                      (default: "fmu/in/vehicle_command")
+   */
+  explicit VehicleCommandSender(rclcpp::Node& node, const std::string& topic_namespace_prefix,
+                                const std::string& command_topic = "fmu/in/vehicle_command");
+
+  /**
+   * @brief Publish @p cmd and wait for a matching VehicleCommandAck.
+   *
+   * Retries up to 3 times with a 300 ms timeout per attempt.
+   * The ACK is matched on (command, target_component == cmd.source_component).
+   *
+   * @return Result::Success on ACK accepted, Result::Rejected on ACK
+   *         rejected, Result::Timeout if no ACK is received.
+   */
+  Result sendCommandSync(px4_msgs::msg::VehicleCommand cmd);
+
+ private:
+  rclcpp::Node& _node;
+  std::string _topic_namespace_prefix;
+  rclcpp::Publisher<px4_msgs::msg::VehicleCommand>::SharedPtr _vehicle_command_pub;
+};
+
+/** @}*/
+}  // namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/utils/vehicle_command_sender.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/utils/vehicle_command_sender.hpp
@@ -32,7 +32,7 @@ class VehicleCommandSender {
    * @param command_topic command topic name without prefix/version suffix
    *                      (default: "fmu/in/vehicle_command")
    */
-  explicit VehicleCommandSender(rclcpp::Node& node, const std::string& topic_namespace_prefix,
+  explicit VehicleCommandSender(rclcpp::Node& node, std::string topic_namespace_prefix,
                                 const std::string& command_topic = "fmu/in/vehicle_command");
 
   /**

--- a/px4_ros2_cpp/include/px4_ros2/vehicle_state/home_position_setter.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/vehicle_state/home_position_setter.hpp
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#pragma once
+
+#include <Eigen/Core>
+#include <px4_msgs/msg/vehicle_command.hpp>
+#include <px4_ros2/common/context.hpp>
+#include <px4_ros2/utils/message_version.hpp>
+
+namespace px4_ros2 {
+/** \ingroup vehicle_state
+ *  @{
+ */
+
+/**
+ * @brief Utility to set the vehicle's home position and GPS global origin.
+ *
+ * Sends VEHICLE_CMD_DO_SET_HOME and VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN
+ * commands to PX4 via the vehicle_command topic.
+ *
+ * @ingroup vehicle_state
+ */
+class HomePositionSetter {
+ public:
+  explicit HomePositionSetter(Context& context);
+
+  /**
+   * @brief Set the home position to the current vehicle position.
+   */
+  void setHomeToCurrentPosition();
+
+  /**
+   * @brief Set the home position to a specific global coordinate.
+   *
+   * @param latitude [deg]
+   * @param longitude [deg]
+   * @param altitude [m AMSL]
+   */
+  void setHome(double latitude, double longitude, float altitude);
+
+  /**
+   * @brief Set the GPS global origin (EKF reference point).
+   *
+   * @param latitude [deg]
+   * @param longitude [deg]
+   * @param altitude [m AMSL]
+   */
+  void setGpsGlobalOrigin(double latitude, double longitude, float altitude);
+
+ private:
+  void sendCommand(uint32_t command, float param1 = 0.f, float param2 = 0.f, float param3 = 0.f,
+                   float param4 = 0.f, double param5 = 0.0, double param6 = 0.0,
+                   float param7 = 0.f);
+
+  rclcpp::Node& _node;
+  rclcpp::Publisher<px4_msgs::msg::VehicleCommand>::SharedPtr _vehicle_command_pub;
+};
+
+/** @}*/
+}  // namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/vehicle_state/home_position_setter.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/vehicle_state/home_position_setter.hpp
@@ -5,10 +5,9 @@
 
 #pragma once
 
-#include <Eigen/Core>
-#include <px4_msgs/msg/vehicle_command.hpp>
 #include <px4_ros2/common/context.hpp>
-#include <px4_ros2/utils/message_version.hpp>
+#include <px4_ros2/components/mode.hpp>
+#include <px4_ros2/utils/vehicle_command_sender.hpp>
 
 namespace px4_ros2 {
 /** \ingroup vehicle_state
@@ -19,7 +18,7 @@ namespace px4_ros2 {
  * @brief Utility to set the vehicle's home position and GPS global origin.
  *
  * Sends VEHICLE_CMD_DO_SET_HOME and VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN
- * commands to PX4 via the vehicle_command topic.
+ * commands to PX4 via the vehicle_command topic and waits for an ACK.
  *
  * @ingroup vehicle_state
  */
@@ -29,8 +28,9 @@ class HomePositionSetter {
 
   /**
    * @brief Set the home position to the current vehicle position.
+   * @return Result::Success on ACK accepted, error otherwise.
    */
-  void setHomeToCurrentPosition();
+  Result setHomeToCurrentPosition();
 
   /**
    * @brief Set the home position to a specific global coordinate.
@@ -38,8 +38,9 @@ class HomePositionSetter {
    * @param latitude [deg]
    * @param longitude [deg]
    * @param altitude [m AMSL]
+   * @return Result::Success on ACK accepted, error otherwise.
    */
-  void setHome(double latitude, double longitude, float altitude);
+  Result setHome(double latitude, double longitude, float altitude);
 
   /**
    * @brief Set the GPS global origin (EKF reference point).
@@ -47,16 +48,16 @@ class HomePositionSetter {
    * @param latitude [deg]
    * @param longitude [deg]
    * @param altitude [m AMSL]
+   * @return Result::Success on ACK accepted, error otherwise.
    */
-  void setGpsGlobalOrigin(double latitude, double longitude, float altitude);
+  Result setGpsGlobalOrigin(double latitude, double longitude, float altitude);
 
  private:
-  void sendCommand(uint32_t command, float param1 = 0.f, float param2 = 0.f, float param3 = 0.f,
-                   float param4 = 0.f, double param5 = 0.0, double param6 = 0.0,
-                   float param7 = 0.f);
+  Result sendCommand(uint32_t command, float param1 = 0.f, float param2 = 0.f, float param3 = 0.f,
+                     float param4 = 0.f, double param5 = 0.0, double param6 = 0.0,
+                     float param7 = 0.f);
 
-  rclcpp::Node& _node;
-  rclcpp::Publisher<px4_msgs::msg::VehicleCommand>::SharedPtr _vehicle_command_pub;
+  VehicleCommandSender _command_sender;
 };
 
 /** @}*/

--- a/px4_ros2_cpp/src/utils/vehicle_command_sender.cpp
+++ b/px4_ros2_cpp/src/utils/vehicle_command_sender.cpp
@@ -9,8 +9,7 @@ using namespace std::chrono_literals;
 
 namespace px4_ros2 {
 
-VehicleCommandSender::VehicleCommandSender(rclcpp::Node& node,
-                                           std::string topic_namespace_prefix,
+VehicleCommandSender::VehicleCommandSender(rclcpp::Node& node, std::string topic_namespace_prefix,
                                            const std::string& command_topic)
     : _node(node), _topic_namespace_prefix(std::move(topic_namespace_prefix))
 {

--- a/px4_ros2_cpp/src/utils/vehicle_command_sender.cpp
+++ b/px4_ros2_cpp/src/utils/vehicle_command_sender.cpp
@@ -10,9 +10,9 @@ using namespace std::chrono_literals;
 namespace px4_ros2 {
 
 VehicleCommandSender::VehicleCommandSender(rclcpp::Node& node,
-                                           const std::string& topic_namespace_prefix,
+                                           std::string topic_namespace_prefix,
                                            const std::string& command_topic)
-    : _node(node), _topic_namespace_prefix(topic_namespace_prefix)
+    : _node(node), _topic_namespace_prefix(std::move(topic_namespace_prefix))
 {
   _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
       _topic_namespace_prefix + command_topic +

--- a/px4_ros2_cpp/src/utils/vehicle_command_sender.cpp
+++ b/px4_ros2_cpp/src/utils/vehicle_command_sender.cpp
@@ -1,0 +1,96 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#include <px4_ros2/utils/vehicle_command_sender.hpp>
+
+using namespace std::chrono_literals;
+
+namespace px4_ros2 {
+
+VehicleCommandSender::VehicleCommandSender(rclcpp::Node& node,
+                                           const std::string& topic_namespace_prefix,
+                                           const std::string& command_topic)
+    : _node(node), _topic_namespace_prefix(topic_namespace_prefix)
+{
+  _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
+      _topic_namespace_prefix + command_topic +
+          px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
+      1);
+}
+
+Result VehicleCommandSender::sendCommandSync(px4_msgs::msg::VehicleCommand cmd)
+{
+  Result result{Result::Rejected};
+  cmd.timestamp = 0;  // Let PX4 set the timestamp
+
+  // Create a fresh subscription each call to avoid ROS Jazzy WaitSet conflicts
+  const auto vehicle_command_ack_sub = _node.create_subscription<px4_msgs::msg::VehicleCommandAck>(
+      _topic_namespace_prefix + "fmu/out/vehicle_command_ack" +
+          px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommandAck>(),
+      rclcpp::QoS(1).best_effort(), [](px4_msgs::msg::VehicleCommandAck::UniquePtr) {});
+
+  // Wait until we have a publisher on the ACK topic
+  auto start_time = std::chrono::steady_clock::now();
+  while (vehicle_command_ack_sub->get_publisher_count() == 0) {
+    const auto timeout = 3000ms;
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= start_time + timeout) {
+      RCLCPP_WARN(_node.get_logger(), "Timeout waiting for vehicle_command_ack publisher");
+      break;
+    }
+  }
+
+  rclcpp::WaitSet wait_set;
+  wait_set.add_subscription(vehicle_command_ack_sub);
+
+  bool got_reply = false;
+
+  for (int retries = 0; retries < 3 && !got_reply; ++retries) {
+    _vehicle_command_pub->publish(cmd);
+    start_time = std::chrono::steady_clock::now();
+    const auto timeout = 300ms;
+    while (!got_reply) {
+      auto now = std::chrono::steady_clock::now();
+
+      if (now >= start_time + timeout) {
+        break;
+      }
+
+      auto wait_ret = wait_set.wait(timeout - (now - start_time));
+
+      if (wait_ret.kind() == rclcpp::WaitResultKind::Ready) {
+        px4_msgs::msg::VehicleCommandAck ack;
+        rclcpp::MessageInfo info;
+
+        if (vehicle_command_ack_sub->take(ack, info)) {
+          if (ack.command == cmd.command && ack.target_component == cmd.source_component) {
+            if (ack.result == px4_msgs::msg::VehicleCommandAck::VEHICLE_CMD_RESULT_ACCEPTED) {
+              result = Result::Success;
+            }
+
+            got_reply = true;
+          }
+
+        } else {
+          RCLCPP_DEBUG(_node.get_logger(), "No VehicleCommandAck message received");
+        }
+
+      } else {
+        RCLCPP_DEBUG(_node.get_logger(), "timeout");
+      }
+    }
+  }
+
+  wait_set.remove_subscription(vehicle_command_ack_sub);
+
+  if (!got_reply) {
+    result = Result::Timeout;
+    RCLCPP_WARN(_node.get_logger(), "Cmd %i: timeout, no ack received", cmd.command);
+  }
+
+  return result;
+}
+
+}  // namespace px4_ros2

--- a/px4_ros2_cpp/src/vehicle_state/home_position_setter.cpp
+++ b/px4_ros2_cpp/src/vehicle_state/home_position_setter.cpp
@@ -22,14 +22,14 @@ void HomePositionSetter::setHomeToCurrentPosition()
 
 void HomePositionSetter::setHome(double latitude, double longitude, float altitude)
 {
-  sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_DO_SET_HOME, 0.f, 0.f, 0.f, 0.f,
-              latitude, longitude, altitude);
+  sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_DO_SET_HOME, 0.f, 0.f, 0.f, 0.f, latitude,
+              longitude, altitude);
 }
 
 void HomePositionSetter::setGpsGlobalOrigin(double latitude, double longitude, float altitude)
 {
-  sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN, 0.f, 0.f, 0.f,
-              0.f, latitude, longitude, altitude);
+  sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN, 0.f, 0.f, 0.f, 0.f,
+              latitude, longitude, altitude);
 }
 
 void HomePositionSetter::sendCommand(uint32_t command, float param1, float param2, float param3,

--- a/px4_ros2_cpp/src/vehicle_state/home_position_setter.cpp
+++ b/px4_ros2_cpp/src/vehicle_state/home_position_setter.cpp
@@ -1,0 +1,53 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#include <px4_ros2/vehicle_state/home_position_setter.hpp>
+
+namespace px4_ros2 {
+
+HomePositionSetter::HomePositionSetter(Context& context) : _node(context.node())
+{
+  _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
+      context.topicNamespacePrefix() + "fmu/in/vehicle_command" +
+          px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
+      1);
+}
+
+void HomePositionSetter::setHomeToCurrentPosition()
+{
+  sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_DO_SET_HOME, 1.f);
+}
+
+void HomePositionSetter::setHome(double latitude, double longitude, float altitude)
+{
+  sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_DO_SET_HOME, 0.f, 0.f, 0.f, 0.f,
+              latitude, longitude, altitude);
+}
+
+void HomePositionSetter::setGpsGlobalOrigin(double latitude, double longitude, float altitude)
+{
+  sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN, 0.f, 0.f, 0.f,
+              0.f, latitude, longitude, altitude);
+}
+
+void HomePositionSetter::sendCommand(uint32_t command, float param1, float param2, float param3,
+                                     float param4, double param5, double param6, float param7)
+{
+  px4_msgs::msg::VehicleCommand cmd{};
+  cmd.command = command;
+  cmd.param1 = param1;
+  cmd.param2 = param2;
+  cmd.param3 = param3;
+  cmd.param4 = param4;
+  cmd.param5 = param5;
+  cmd.param6 = param6;
+  cmd.param7 = param7;
+  cmd.target_system = 0;
+  cmd.target_component = 1;
+  cmd.timestamp = 0;  // Let PX4 set the timestamp
+  _vehicle_command_pub->publish(cmd);
+}
+
+}  // namespace px4_ros2

--- a/px4_ros2_cpp/src/vehicle_state/home_position_setter.cpp
+++ b/px4_ros2_cpp/src/vehicle_state/home_position_setter.cpp
@@ -7,33 +7,30 @@
 
 namespace px4_ros2 {
 
-HomePositionSetter::HomePositionSetter(Context& context) : _node(context.node())
+HomePositionSetter::HomePositionSetter(Context& context)
+    : _command_sender(context.node(), context.topicNamespacePrefix())
 {
-  _vehicle_command_pub = _node.create_publisher<px4_msgs::msg::VehicleCommand>(
-      context.topicNamespacePrefix() + "fmu/in/vehicle_command" +
-          px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
-      1);
 }
 
-void HomePositionSetter::setHomeToCurrentPosition()
+Result HomePositionSetter::setHomeToCurrentPosition()
 {
-  sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_DO_SET_HOME, 1.f);
+  return sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_DO_SET_HOME, 1.f);
 }
 
-void HomePositionSetter::setHome(double latitude, double longitude, float altitude)
+Result HomePositionSetter::setHome(double latitude, double longitude, float altitude)
 {
-  sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_DO_SET_HOME, 0.f, 0.f, 0.f, 0.f, latitude,
-              longitude, altitude);
+  return sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_DO_SET_HOME, 0.f, 0.f, 0.f, 0.f,
+                     latitude, longitude, altitude);
 }
 
-void HomePositionSetter::setGpsGlobalOrigin(double latitude, double longitude, float altitude)
+Result HomePositionSetter::setGpsGlobalOrigin(double latitude, double longitude, float altitude)
 {
-  sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN, 0.f, 0.f, 0.f, 0.f,
-              latitude, longitude, altitude);
+  return sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN, 0.f, 0.f,
+                     0.f, 0.f, latitude, longitude, altitude);
 }
 
-void HomePositionSetter::sendCommand(uint32_t command, float param1, float param2, float param3,
-                                     float param4, double param5, double param6, float param7)
+Result HomePositionSetter::sendCommand(uint32_t command, float param1, float param2, float param3,
+                                       float param4, double param5, double param6, float param7)
 {
   px4_msgs::msg::VehicleCommand cmd{};
   cmd.command = command;
@@ -46,8 +43,7 @@ void HomePositionSetter::sendCommand(uint32_t command, float param1, float param
   cmd.param7 = param7;
   cmd.target_system = 0;
   cmd.target_component = 1;
-  cmd.timestamp = 0;  // Let PX4 set the timestamp
-  _vehicle_command_pub->publish(cmd);
+  return _command_sender.sendCommandSync(cmd);
 }
 
 }  // namespace px4_ros2

--- a/px4_ros2_cpp/test/integration/home_position_setter.cpp
+++ b/px4_ros2_cpp/test/integration/home_position_setter.cpp
@@ -24,16 +24,16 @@ TEST_F(ModesTest, HomePositionSetter)
 
   // Set GPS global origin (EKF reference point)
   auto result = setter.setGpsGlobalOrigin(47.397742, 8.545594, 488.f);
-  EXPECT_EQ(result, px4_ros2::Result::Success) << "setGpsGlobalOrigin failed: "
-                                                << px4_ros2::resultToString(result);
+  EXPECT_EQ(result, px4_ros2::Result::Success)
+      << "setGpsGlobalOrigin failed: " << px4_ros2::resultToString(result);
 
   // Set home to current vehicle position
   result = setter.setHomeToCurrentPosition();
-  EXPECT_EQ(result, px4_ros2::Result::Success) << "setHomeToCurrentPosition failed: "
-                                                << px4_ros2::resultToString(result);
+  EXPECT_EQ(result, px4_ros2::Result::Success)
+      << "setHomeToCurrentPosition failed: " << px4_ros2::resultToString(result);
 
   // Set home to specific global coordinates
   result = setter.setHome(47.398, 8.546, 490.f);
-  EXPECT_EQ(result, px4_ros2::Result::Success) << "setHome failed: "
-                                                << px4_ros2::resultToString(result);
+  EXPECT_EQ(result, px4_ros2::Result::Success)
+      << "setHome failed: " << px4_ros2::resultToString(result);
 }

--- a/px4_ros2_cpp/test/integration/home_position_setter.cpp
+++ b/px4_ros2_cpp/test/integration/home_position_setter.cpp
@@ -1,0 +1,39 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <px4_ros2/common/context.hpp>
+#include <px4_ros2/components/wait_for_fmu.hpp>
+#include <px4_ros2/vehicle_state/home_position_setter.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "util.hpp"
+
+using namespace std::chrono_literals;
+
+TEST_F(ModesTest, HomePositionSetter)
+{
+  auto test_node = initNode();
+  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s));
+
+  px4_ros2::Context context(*test_node);
+  px4_ros2::HomePositionSetter setter(context);
+
+  // Set GPS global origin (EKF reference point)
+  auto result = setter.setGpsGlobalOrigin(47.397742, 8.545594, 488.f);
+  EXPECT_EQ(result, px4_ros2::Result::Success) << "setGpsGlobalOrigin failed: "
+                                                << px4_ros2::resultToString(result);
+
+  // Set home to current vehicle position
+  result = setter.setHomeToCurrentPosition();
+  EXPECT_EQ(result, px4_ros2::Result::Success) << "setHomeToCurrentPosition failed: "
+                                                << px4_ros2::resultToString(result);
+
+  // Set home to specific global coordinates
+  result = setter.setHome(47.398, 8.546, 490.f);
+  EXPECT_EQ(result, px4_ros2::Result::Success) << "setHome failed: "
+                                                << px4_ros2::resultToString(result);
+}

--- a/px4_ros2_cpp/test/unit/vehicle_command_sender.cpp
+++ b/px4_ros2_cpp/test/unit/vehicle_command_sender.cpp
@@ -5,8 +5,6 @@
 
 #include <gtest/gtest.h>
 
-#include <thread>
-
 #include <px4_msgs/msg/vehicle_command.hpp>
 #include <px4_msgs/msg/vehicle_command_ack.hpp>
 #include <px4_ros2/common/context.hpp>
@@ -15,6 +13,7 @@
 #include <px4_ros2/utils/vehicle_command_sender.hpp>
 #include <px4_ros2/vehicle_state/home_position_setter.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <thread>
 
 using namespace std::chrono_literals;
 
@@ -38,8 +37,7 @@ class FakeCommandResponder {
     _cmd_sub = node.create_subscription<px4_msgs::msg::VehicleCommand>(
         topic_prefix + "fmu/in/vehicle_command" +
             px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
-        rclcpp::QoS(1),
-        [this, ack_result](px4_msgs::msg::VehicleCommand::UniquePtr msg) {
+        rclcpp::QoS(1), [this, ack_result](px4_msgs::msg::VehicleCommand::UniquePtr msg) {
           px4_msgs::msg::VehicleCommandAck ack{};
           ack.command = msg->command;
           ack.target_component = msg->source_component;
@@ -81,8 +79,7 @@ class VehicleCommandSenderTest : public testing::Test {
   void startResponder(
       uint8_t ack_result = px4_msgs::msg::VehicleCommandAck::VEHICLE_CMD_RESULT_ACCEPTED)
   {
-    _responder =
-        std::make_unique<FakeCommandResponder>(*_responder_node, kTopicPrefix, ack_result);
+    _responder = std::make_unique<FakeCommandResponder>(*_responder_node, kTopicPrefix, ack_result);
     _spin_thread = std::thread([this]() { _executor->spin(); });
     std::this_thread::sleep_for(50ms);  // allow DDS discovery
   }

--- a/px4_ros2_cpp/test/unit/vehicle_command_sender.cpp
+++ b/px4_ros2_cpp/test/unit/vehicle_command_sender.cpp
@@ -1,0 +1,170 @@
+/****************************************************************************
+ * Copyright (c) 2025 PX4 Development Team.
+ * SPDX-License-Identifier: BSD-3-Clause
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+#include <px4_msgs/msg/vehicle_command.hpp>
+#include <px4_msgs/msg/vehicle_command_ack.hpp>
+#include <px4_ros2/common/context.hpp>
+#include <px4_ros2/components/mode.hpp>
+#include <px4_ros2/utils/message_version.hpp>
+#include <px4_ros2/utils/vehicle_command_sender.hpp>
+#include <px4_ros2/vehicle_state/home_position_setter.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr const char* kTopicPrefix = "/test_cmd_sender/";
+
+/**
+ * Simulates PX4's command-ACK behavior: subscribes to vehicle_command,
+ * publishes a matching VehicleCommandAck on receipt.
+ */
+class FakeCommandResponder {
+ public:
+  FakeCommandResponder(rclcpp::Node& node, const std::string& topic_prefix, uint8_t ack_result)
+  {
+    _ack_pub = node.create_publisher<px4_msgs::msg::VehicleCommandAck>(
+        topic_prefix + "fmu/out/vehicle_command_ack" +
+            px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommandAck>(),
+        rclcpp::QoS(1).best_effort());
+
+    _cmd_sub = node.create_subscription<px4_msgs::msg::VehicleCommand>(
+        topic_prefix + "fmu/in/vehicle_command" +
+            px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>(),
+        rclcpp::QoS(1),
+        [this, ack_result](px4_msgs::msg::VehicleCommand::UniquePtr msg) {
+          px4_msgs::msg::VehicleCommandAck ack{};
+          ack.command = msg->command;
+          ack.target_component = msg->source_component;
+          ack.result = ack_result;
+          _ack_pub->publish(ack);
+        });
+  }
+
+ private:
+  rclcpp::Publisher<px4_msgs::msg::VehicleCommandAck>::SharedPtr _ack_pub;
+  rclcpp::Subscription<px4_msgs::msg::VehicleCommand>::SharedPtr _cmd_sub;
+};
+
+}  // namespace
+
+/**
+ * Test fixture: uses a separate responder node (with its own executor thread)
+ * so that VehicleCommandSender's internal WaitSet on the test node has no
+ * conflict with the executor driving the fake responder callbacks.
+ */
+class VehicleCommandSenderTest : public testing::Test {
+ protected:
+  void SetUp() override
+  {
+    _test_node = std::make_shared<rclcpp::Node>("test_cmd_node");
+    _responder_node = std::make_shared<rclcpp::Node>("responder_node");
+    _executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    _executor->add_node(_responder_node);
+  }
+
+  void TearDown() override
+  {
+    _executor->cancel();
+    if (_spin_thread.joinable()) {
+      _spin_thread.join();
+    }
+  }
+
+  void startResponder(
+      uint8_t ack_result = px4_msgs::msg::VehicleCommandAck::VEHICLE_CMD_RESULT_ACCEPTED)
+  {
+    _responder =
+        std::make_unique<FakeCommandResponder>(*_responder_node, kTopicPrefix, ack_result);
+    _spin_thread = std::thread([this]() { _executor->spin(); });
+    std::this_thread::sleep_for(50ms);  // allow DDS discovery
+  }
+
+  std::shared_ptr<rclcpp::Node> _test_node;
+  std::shared_ptr<rclcpp::Node> _responder_node;
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> _executor;
+  std::unique_ptr<FakeCommandResponder> _responder;
+  std::thread _spin_thread;
+};
+
+// ---------------------------------------------------------------------------
+// VehicleCommandSender
+// ---------------------------------------------------------------------------
+
+TEST_F(VehicleCommandSenderTest, Accepted)
+{
+  startResponder(px4_msgs::msg::VehicleCommandAck::VEHICLE_CMD_RESULT_ACCEPTED);
+  px4_ros2::VehicleCommandSender sender(*_test_node, kTopicPrefix);
+
+  px4_msgs::msg::VehicleCommand cmd{};
+  cmd.command = px4_msgs::msg::VehicleCommand::VEHICLE_CMD_DO_SET_HOME;
+
+  EXPECT_EQ(sender.sendCommandSync(cmd), px4_ros2::Result::Success);
+}
+
+TEST_F(VehicleCommandSenderTest, Rejected)
+{
+  startResponder(px4_msgs::msg::VehicleCommandAck::VEHICLE_CMD_RESULT_DENIED);
+  px4_ros2::VehicleCommandSender sender(*_test_node, kTopicPrefix);
+
+  px4_msgs::msg::VehicleCommand cmd{};
+  cmd.command = px4_msgs::msg::VehicleCommand::VEHICLE_CMD_DO_SET_HOME;
+
+  EXPECT_EQ(sender.sendCommandSync(cmd), px4_ros2::Result::Rejected);
+}
+
+TEST_F(VehicleCommandSenderTest, Timeout)
+{
+  // Create an ACK publisher so the "wait for publisher" loop exits quickly,
+  // but do NOT set up a command responder — no ACK will ever be sent.
+  _responder_node->create_publisher<px4_msgs::msg::VehicleCommandAck>(
+      std::string(kTopicPrefix) + "fmu/out/vehicle_command_ack" +
+          px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommandAck>(),
+      rclcpp::QoS(1).best_effort());
+  _spin_thread = std::thread([this]() { _executor->spin(); });
+  std::this_thread::sleep_for(50ms);
+
+  px4_ros2::VehicleCommandSender sender(*_test_node, kTopicPrefix);
+  px4_msgs::msg::VehicleCommand cmd{};
+  cmd.command = px4_msgs::msg::VehicleCommand::VEHICLE_CMD_DO_SET_HOME;
+
+  EXPECT_EQ(sender.sendCommandSync(cmd), px4_ros2::Result::Timeout);
+}
+
+// ---------------------------------------------------------------------------
+// HomePositionSetter (uses VehicleCommandSender internally)
+// ---------------------------------------------------------------------------
+
+TEST_F(VehicleCommandSenderTest, HomeSetCurrentPosition)
+{
+  startResponder();
+  px4_ros2::Context context(*_test_node, kTopicPrefix);
+  px4_ros2::HomePositionSetter setter(context);
+
+  EXPECT_EQ(setter.setHomeToCurrentPosition(), px4_ros2::Result::Success);
+}
+
+TEST_F(VehicleCommandSenderTest, HomeSetCoordinates)
+{
+  startResponder();
+  px4_ros2::Context context(*_test_node, kTopicPrefix);
+  px4_ros2::HomePositionSetter setter(context);
+
+  EXPECT_EQ(setter.setHome(47.398, 8.546, 490.f), px4_ros2::Result::Success);
+}
+
+TEST_F(VehicleCommandSenderTest, HomeSetGpsGlobalOrigin)
+{
+  startResponder();
+  px4_ros2::Context context(*_test_node, kTopicPrefix);
+  px4_ros2::HomePositionSetter setter(context);
+
+  EXPECT_EQ(setter.setGpsGlobalOrigin(47.397742, 8.545594, 488.f), px4_ros2::Result::Success);
+}


### PR DESCRIPTION
## Summary
Add a `HomePositionSetter` utility class for sending `VEHICLE_CMD_DO_SET_HOME` and `VEHICLE_CMD_SET_GPS_GLOBAL_ORIGIN` commands to PX4, as suggested by @bkueng in #108.

- `setHomeToCurrentPosition()` — sets home to current vehicle position
- `setHome(lat, lon, alt)` — sets home to a specific global coordinate
- `setGpsGlobalOrigin(lat, lon, alt)` — sets the EKF reference point

All methods send the command and **wait for an ACK** (3 retries × 300 ms timeout), returning a `Result` enum.

The ACK-waiting logic is extracted into a reusable `VehicleCommandSender` utility (`px4_ros2/utils/vehicle_command_sender.hpp`), modeled after the pattern in `ModeExecutorBase::sendCommandSync()`. This helper accepts a configurable command topic, so `ModeExecutorBase` can also be migrated to it in a follow-up.

Ref #108

## Test plan
- [x] `colcon build --packages-select px4_ros2_cpp` passes (ROS2 Jazzy)
- [x] Unit tests: `VehicleCommandSender` (accepted / rejected / timeout) + `HomePositionSetter` (all 3 methods) with fake ACK responder
- [x] Integration test: verifies all 3 methods against PX4 SITL
- [x] SITL integration test (PX4 main + Gazebo + XRCE-DDS agent):
  - `setGpsGlobalOrigin(47.397742, 8.545594, 488.0)` — ACK cmd=100000 result=0
  - `setHomeToCurrentPosition()` — ACK cmd=179 result=0, home=47.397971,8.546164
  - `setHome(47.398, 8.546, 490)` — ACK cmd=179 result=0, home=47.398000,8.546000,490.00