### PR TITLE
chore: bump px4_msgs to 3.4.0

### DIFF
--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -27,6 +27,10 @@ if($ENV{ROS_DISTRO} STREQUAL "humble" OR $ENV{ROS_DISTRO} STREQUAL "galactic")
     add_compile_definitions(ROS2_HUMBLE_OR_GALACTIC)
 endif()
 
+if($ENV{ROS_DISTRO} STREQUAL "rolling")
+        add_compile_definitions(ROS2_ROLLING)
+endif()
+
 # Galactic lacks add_pre_shutdown_callback; assume present otherwise.
 set(HAS_RCLCPP_PRE_SHUTDOWN ON)
 if($ENV{ROS_DISTRO} STREQUAL "galactic")

--- a/px4_ros2_cpp/rosdep-humble.yaml
+++ b/px4_ros2_cpp/rosdep-humble.yaml
@@ -1,3 +1,3 @@
 px4_msgs:
   ubuntu:
-    - ros-humble-px4-msgs=3.3.100-0jammy
+    - ros-humble-px4-msgs=3.4.0-0jammy

--- a/px4_ros2_cpp/rosdep-jazzy.yaml
+++ b/px4_ros2_cpp/rosdep-jazzy.yaml
@@ -1,3 +1,3 @@
 px4_msgs:
   ubuntu:
-    - ros-jazzy-px4-msgs=3.3.100-0noble
+    - ros-jazzy-px4-msgs=3.4.0-0noble

--- a/px4_ros2_cpp/rosdep-rolling.yaml
+++ b/px4_ros2_cpp/rosdep-rolling.yaml
@@ -1,3 +1,3 @@
 px4_msgs:
   ubuntu:
-    - ros-rolling-px4-msgs=3.3.100-0noble
+    - ros-rolling-px4-msgs=3.4.0-0noble

--- a/px4_ros2_cpp/src/components/message_compatibility_check.cpp
+++ b/px4_ros2_cpp/src/components/message_compatibility_check.cpp
@@ -8,6 +8,9 @@
 #include <unistd.h>
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#ifdef ROS2_ROLLING
+#include <filesystem>
+#endif
 #include <fstream>
 #include <px4_all_messages.hpp>
 #include <px4_msgs/msg/message_format_request.hpp>
@@ -283,7 +286,13 @@ bool messageCompatibilityCheck(rclcpp::Node& node,
                 px4_ros2::getMessageNameVersion<px4_msgs::msg::MessageFormatRequest>(),
             1);
 
+#ifdef ROS2_ROLLING
+    std::filesystem::path msgs_dir_path;
+    ament_index_cpp::get_package_share_directory("px4_msgs", msgs_dir_path);
+    const std::string msgs_dir = msgs_dir_path.string();
+#else
     const std::string msgs_dir = ament_index_cpp::get_package_share_directory("px4_msgs");
+#endif
     if (msgs_dir.empty()) {
       RCLCPP_FATAL(node.get_logger(),
                    "Failed to get installation directory for 'px4_msgs' package");


### PR DESCRIPTION
### Changes

- Bump px4_msgs to `3.4.0`
- ROS2 Rolling: use new ament_index API for `get_package_share_directory()` (current was deprecated)