### PR TITLE
Two-phase wait for fmu

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/components/wait_for_fmu.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/wait_for_fmu.hpp
@@ -14,9 +14,34 @@ namespace px4_ros2 {
  *  @{
  */
 /**
- * Wait for a heartbeat/status message from the FMU
+ * Wait for the FMU to be discoverable and emit its first heartbeat/status message.
+ *
+ * The wait happens in two phases:
+ *   1. Discovery: poll the ROS graph until the vehicle_status publisher is visible,
+ *      bounded by @p discovery_timeout. Covers slow DDS endpoint discovery (e.g.
+ *      cold boot).
+ *   2. Heartbeat: wait for the first vehicle_status message on the now-matched
+ *      subscription, bounded by @p heartbeat_timeout. Should be short — fails
+ *      fast when the FMU is discovered but silent.
+ *
+ * @return true if both phases succeed before their respective timeouts.
+ */
+bool waitForFMU(rclcpp::Node& node, const rclcpp::Duration& discovery_timeout,
+                const rclcpp::Duration& heartbeat_timeout,
+                const std::string& topic_namespace_prefix = "");
+
+/**
+ * Wait for a heartbeat/status message from the FMU.
+ *
+ * @deprecated Use the (discovery_timeout, heartbeat_timeout) overload for finer
+ *   control over the cold-boot discovery phase versus the heartbeat phase.
+ *   This overload calls the new one with both timeouts set to @p timeout, so
+ *   the worst-case wait is unchanged.
  * @return true on success
  */
+[[deprecated(
+    "Use waitForFMU(node, discovery_timeout, heartbeat_timeout, prefix) "
+    "for finer control over discovery vs heartbeat timeouts.")]]
 bool waitForFMU(rclcpp::Node& node, const rclcpp::Duration& timeout = 30s,
                 const std::string& topic_namespace_prefix = "");
 

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -75,9 +75,8 @@ bool ModeBase::doRegister()
 {
   assert(!_registration->registered());
 
-  if (!_skip_message_compatibility_check &&
-      (!waitForFMU(node(), 15s, 5s, topicNamespacePrefix()) ||
-       !defaultMessageCompatibilityCheck())) {
+  if (!_skip_message_compatibility_check && (!waitForFMU(node(), 15s, 5s, topicNamespacePrefix()) ||
+                                             !defaultMessageCompatibilityCheck())) {
     return false;
   }
 

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -76,7 +76,8 @@ bool ModeBase::doRegister()
   assert(!_registration->registered());
 
   if (!_skip_message_compatibility_check &&
-      (!waitForFMU(node(), 15s, topicNamespacePrefix()) || !defaultMessageCompatibilityCheck())) {
+      (!waitForFMU(node(), 15s, 5s, topicNamespacePrefix()) ||
+       !defaultMessageCompatibilityCheck())) {
     return false;
   }
 

--- a/px4_ros2_cpp/src/components/mode_executor.cpp
+++ b/px4_ros2_cpp/src/components/mode_executor.cpp
@@ -59,8 +59,9 @@ bool ModeExecutorBase::doRegister()
 
   assert(!_registration->registered());
 
-  if (!_skip_message_compatibility_check && (!waitForFMU(node(), 15s, _topic_namespace_prefix) ||
-                                             !_owned_mode.defaultMessageCompatibilityCheck())) {
+  if (!_skip_message_compatibility_check &&
+      (!waitForFMU(node(), 15s, 5s, _topic_namespace_prefix) ||
+       !_owned_mode.defaultMessageCompatibilityCheck())) {
     return false;
   }
 

--- a/px4_ros2_cpp/src/components/wait_for_fmu.cpp
+++ b/px4_ros2_cpp/src/components/wait_for_fmu.cpp
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  ****************************************************************************/
 
+#include <chrono>
 #include <px4_msgs/msg/vehicle_status.hpp>
 #include <px4_ros2/components/wait_for_fmu.hpp>
 #include <px4_ros2/utils/message_version.hpp>
-
-#include <chrono>
 #include <thread>
 
 namespace px4_ros2 {
@@ -18,11 +17,10 @@ bool waitForFMU(rclcpp::Node& node, const rclcpp::Duration& discovery_timeout,
 {
   RCLCPP_DEBUG(node.get_logger(), "Waiting for FMU...");
   const std::string topic = topic_namespace_prefix + "fmu/out/vehicle_status" +
-      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>();
+                            px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>();
   const rclcpp::Subscription<px4_msgs::msg::VehicleStatus>::SharedPtr vehicle_status_sub =
       node.create_subscription<px4_msgs::msg::VehicleStatus>(
-          topic, rclcpp::QoS(1).best_effort(),
-          [](px4_msgs::msg::VehicleStatus::UniquePtr msg) {});
+          topic, rclcpp::QoS(1).best_effort(), [](px4_msgs::msg::VehicleStatus::UniquePtr msg) {});
 
   // Phase 1: wait for the FMU's vehicle_status publisher to appear on the graph.
   using namespace std::chrono_literals;  // NOLINT

--- a/px4_ros2_cpp/src/components/wait_for_fmu.cpp
+++ b/px4_ros2_cpp/src/components/wait_for_fmu.cpp
@@ -7,33 +7,50 @@
 #include <px4_ros2/components/wait_for_fmu.hpp>
 #include <px4_ros2/utils/message_version.hpp>
 
+#include <chrono>
+#include <thread>
+
 namespace px4_ros2 {
 
-bool waitForFMU(rclcpp::Node& node, const rclcpp::Duration& timeout,
+bool waitForFMU(rclcpp::Node& node, const rclcpp::Duration& discovery_timeout,
+                const rclcpp::Duration& heartbeat_timeout,
                 const std::string& topic_namespace_prefix)
 {
   RCLCPP_DEBUG(node.get_logger(), "Waiting for FMU...");
+  const std::string topic = topic_namespace_prefix + "fmu/out/vehicle_status" +
+      px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>();
   const rclcpp::Subscription<px4_msgs::msg::VehicleStatus>::SharedPtr vehicle_status_sub =
       node.create_subscription<px4_msgs::msg::VehicleStatus>(
-          topic_namespace_prefix + "fmu/out/vehicle_status" +
-              px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleStatus>(),
-          rclcpp::QoS(1).best_effort(), [](px4_msgs::msg::VehicleStatus::UniquePtr msg) {});
+          topic, rclcpp::QoS(1).best_effort(),
+          [](px4_msgs::msg::VehicleStatus::UniquePtr msg) {});
 
+  // Phase 1: wait for the FMU's vehicle_status publisher to appear on the graph.
+  using namespace std::chrono_literals;  // NOLINT
+  const auto discovery_start = node.now();
+  while (node.count_publishers(topic) == 0) {
+    if (node.now() >= discovery_start + discovery_timeout) {
+      RCLCPP_DEBUG(node.get_logger(), "timeout while waiting for FMU publisher discovery");
+      return false;
+    }
+    std::this_thread::sleep_for(50ms);
+  }
+
+  // Phase 2: wait for the first vehicle_status message on the matched subscription.
   rclcpp::WaitSet wait_set;
   wait_set.add_subscription(vehicle_status_sub);
 
   bool got_message = false;
-  auto start_time = node.now();
+  const auto heartbeat_start = node.now();
 
   while (!got_message) {
-    auto now = node.now();
+    const auto now = node.now();
 
-    if (now >= start_time + timeout) {
+    if (now >= heartbeat_start + heartbeat_timeout) {
       break;
     }
 
-    auto wait_ret =
-        wait_set.wait((timeout - (now - start_time)).to_chrono<std::chrono::microseconds>());
+    const auto wait_ret = wait_set.wait(
+        (heartbeat_timeout - (now - heartbeat_start)).to_chrono<std::chrono::microseconds>());
 
     if (wait_ret.kind() == rclcpp::WaitResultKind::Ready) {
       px4_msgs::msg::VehicleStatus msg;
@@ -47,12 +64,18 @@ bool waitForFMU(rclcpp::Node& node, const rclcpp::Duration& timeout,
       }
 
     } else {
-      RCLCPP_DEBUG(node.get_logger(), "timeout while waiting for FMU");
+      RCLCPP_DEBUG(node.get_logger(), "timeout while waiting for FMU heartbeat");
     }
   }
 
   wait_set.remove_subscription(vehicle_status_sub);
   return got_message;
+}
+
+bool waitForFMU(rclcpp::Node& node, const rclcpp::Duration& timeout,
+                const std::string& topic_namespace_prefix)
+{
+  return waitForFMU(node, timeout, timeout, topic_namespace_prefix);
 }
 
 }  // namespace px4_ros2

--- a/px4_ros2_cpp/test/integration/arming_check.cpp
+++ b/px4_ros2_cpp/test/integration/arming_check.cpp
@@ -101,7 +101,7 @@ void TestExecution::run()
 TEST_F(ModesTest, denyArming)
 {
   auto test_node = initNode();
-  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s));
+  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s, 5s));
   TestExecution test_execution{*test_node};
   test_execution.run();
   rclcpp::spin(test_node);

--- a/px4_ros2_cpp/test/integration/home_position_setter.cpp
+++ b/px4_ros2_cpp/test/integration/home_position_setter.cpp
@@ -17,7 +17,7 @@ using namespace std::chrono_literals;
 TEST_F(ModesTest, HomePositionSetter)
 {
   auto test_node = initNode();
-  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s));
+  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s, 5s));
 
   px4_ros2::Context context(*test_node);
   px4_ros2::HomePositionSetter setter(context);

--- a/px4_ros2_cpp/test/integration/mission.cpp
+++ b/px4_ros2_cpp/test/integration/mission.cpp
@@ -130,7 +130,7 @@ void TestMission::run()
 TEST_F(ModesTest, runMission)
 {
   auto test_node = initNode();
-  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s));
+  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s, 5s));
   TestMission test{*test_node};
   test.run();
 }

--- a/px4_ros2_cpp/test/integration/mode.cpp
+++ b/px4_ros2_cpp/test/integration/mode.cpp
@@ -248,7 +248,7 @@ void TestExecution::run()
 TEST_F(ModesTest, runModeTests)
 {
   auto test_node = initNode();
-  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s));
+  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s, 5s));
   TestExecution test_execution{*test_node};
   test_execution.run();
   rclcpp::spin(test_node);

--- a/px4_ros2_cpp/test/integration/mode_executor.cpp
+++ b/px4_ros2_cpp/test/integration/mode_executor.cpp
@@ -198,7 +198,7 @@ void TestExecutionAutonomous::run()
 TEST_F(ModesTest, runExecutorAutonomous)
 {
   auto test_node = initNode();
-  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s));
+  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s, 5s));
   TestExecutionAutonomous test_execution{*test_node};
   test_execution.run();
   rclcpp::spin(test_node);
@@ -358,7 +358,7 @@ void TestExecutionInCharge::run()
 TEST_F(ModesTest, runExecutorInCharge)
 {
   auto test_node = initNode();
-  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s));
+  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s, 5s));
   TestExecutionInCharge test_execution{*test_node};
   test_execution.run();
   rclcpp::spin(test_node);
@@ -457,7 +457,7 @@ void TestExecutionFailsafe::run()
 TEST_F(ModesTest, runExecutorFailsafe)
 {
   auto test_node = initNode();
-  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s));
+  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s, 5s));
   TestExecutionFailsafe test_execution{*test_node};
   test_execution.run();
   rclcpp::spin(test_node);

--- a/px4_ros2_cpp/test/integration/overrides.cpp
+++ b/px4_ros2_cpp/test/integration/overrides.cpp
@@ -254,7 +254,7 @@ void TestExecutionOverrides::run()
 TEST_F(ModesTest, runExecutorOverrides)
 {
   auto test_node = initNode();
-  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s));
+  ASSERT_TRUE(px4_ros2::waitForFMU(*test_node, 10s, 5s));
   TestExecutionOverrides test_execution{*test_node};
   test_execution.run();
   rclcpp::spin(test_node);


### PR DESCRIPTION
`waitForFMU` currently has two very different failure modes under a single timeout:

1. **DDS endpoint discovery** --> slow on cold boot (can take 15-30s). Unavoidable, ros limitation and grows with nodes.
2. **First heartbeat after the publisher is matched** --> should arrive within one publish period. Slow here means the FMU is genuinely unresponsive.

With one knob, callers either increase it generously and lose fast-fail when the FMU is silent, or keep it tight and get boot timeouts. This PR splits the wait into two phases with independent timeouts.