### PR TITLE
feat(mission): add setSkipMessageCompatibilityCheck to MissionExecutor

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/mission/mission_executor.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/mission/mission_executor.hpp
@@ -138,6 +138,15 @@ class MissionExecutor {
    */
   void abort();
 
+  /**
+   * Skip the FMU message-compatibility check on registration.
+   * Must be called before doRegister().
+   */
+  void setSkipMessageCompatibilityCheck()
+  {
+    _mode_executor->setSkipMessageCompatibilityCheck();
+  }
+
  protected:
   class MissionMode : public ModeBase {
    public:
@@ -201,6 +210,12 @@ class MissionExecutor {
       setSkipMessageCompatibilityCheck();
       overrideRegistration(registration);
     }
+
+    void setSkipMessageCompatibilityCheck()
+    {
+      ModeExecutorBase::setSkipMessageCompatibilityCheck();
+    }
+
     std::function<bool(uint32_t, float)> command_handler{nullptr};
     std::function<void()> on_failsafe_deferred{nullptr};
 

--- a/px4_ros2_cpp/include/px4_ros2/mission/mission_executor.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/mission/mission_executor.hpp
@@ -142,10 +142,7 @@ class MissionExecutor {
    * Skip the FMU message-compatibility check on registration.
    * Must be called before doRegister().
    */
-  void setSkipMessageCompatibilityCheck()
-  {
-    _mode_executor->setSkipMessageCompatibilityCheck();
-  }
+  void setSkipMessageCompatibilityCheck() { _mode_executor->setSkipMessageCompatibilityCheck(); }
 
  protected:
   class MissionMode : public ModeBase {


### PR DESCRIPTION
Add `setSkipMessageCompatibilityCheck` to `MissionExecutor` , which propagates to the underlying `MissionModeExecutor` so callers can skip the FMU message compatibility check before `doRegister()`. 

Previously couldn't be skipped since all the relevant methods and/or members were either `protected` or `private`.