### PR TITLE
Fix message compatibility get path with rolling

### DIFF
--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -27,8 +27,12 @@ if($ENV{ROS_DISTRO} STREQUAL "humble" OR $ENV{ROS_DISTRO} STREQUAL "galactic")
     add_compile_definitions(ROS2_HUMBLE_OR_GALACTIC)
 endif()
 
+if($ENV{ROS_DISTRO} STREQUAL "lyrical")
+    add_compile_definitions(ROS2_LYRICAL)
+endif()
+
 if($ENV{ROS_DISTRO} STREQUAL "rolling")
-        add_compile_definitions(ROS2_ROLLING)
+    add_compile_definitions(ROS2_ROLLING)
 endif()
 
 # Galactic lacks add_pre_shutdown_callback; assume present otherwise.

--- a/px4_ros2_cpp/src/components/message_compatibility_check.cpp
+++ b/px4_ros2_cpp/src/components/message_compatibility_check.cpp
@@ -9,8 +9,8 @@
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #ifdef ROS2_ROLLING
-#include <filesystem>
 #include <ament_index_cpp/get_package_share_path.hpp>
+#include <filesystem>
 #endif
 #include <fstream>
 #include <px4_all_messages.hpp>

--- a/px4_ros2_cpp/src/components/message_compatibility_check.cpp
+++ b/px4_ros2_cpp/src/components/message_compatibility_check.cpp
@@ -288,7 +288,7 @@ bool messageCompatibilityCheck(rclcpp::Node& node,
             1);
 
 #ifdef ROS2_ROLLING
-    std::filesystem::path msg_dir_path = ament_index_cpp::get_package_share_path("px4_msgs");
+    std::filesystem::path msgs_dir_path = ament_index_cpp::get_package_share_path("px4_msgs");
     const std::string msgs_dir = msgs_dir_path.string();
 #else
     const std::string msgs_dir = ament_index_cpp::get_package_share_directory("px4_msgs");

--- a/px4_ros2_cpp/src/components/message_compatibility_check.cpp
+++ b/px4_ros2_cpp/src/components/message_compatibility_check.cpp
@@ -8,7 +8,7 @@
 #include <unistd.h>
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
-#ifdef ROS2_ROLLING
+#if defined(ROS2_ROLLING) || defined(ROS2_LYRICAL)
 #include <ament_index_cpp/get_package_share_path.hpp>
 #include <filesystem>
 #endif
@@ -287,7 +287,7 @@ bool messageCompatibilityCheck(rclcpp::Node& node,
                 px4_ros2::getMessageNameVersion<px4_msgs::msg::MessageFormatRequest>(),
             1);
 
-#ifdef ROS2_ROLLING
+#if defined(ROS2_ROLLING) || defined(ROS2_LYRICAL)
     std::filesystem::path msgs_dir_path = ament_index_cpp::get_package_share_path("px4_msgs");
     const std::string msgs_dir = msgs_dir_path.string();
 #else

--- a/px4_ros2_cpp/src/components/message_compatibility_check.cpp
+++ b/px4_ros2_cpp/src/components/message_compatibility_check.cpp
@@ -10,6 +10,7 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #ifdef ROS2_ROLLING
 #include <filesystem>
+#include <ament_index_cpp/get_package_share_path.hpp>
 #endif
 #include <fstream>
 #include <px4_all_messages.hpp>
@@ -287,8 +288,7 @@ bool messageCompatibilityCheck(rclcpp::Node& node,
             1);
 
 #ifdef ROS2_ROLLING
-    std::filesystem::path msgs_dir_path;
-    ament_index_cpp::get_package_share_directory("px4_msgs", msgs_dir_path);
+    std::filesystem::path msg_dir_path = ament_index_cpp::get_package_share_path("px4_msgs");
     const std::string msgs_dir = msgs_dir_path.string();
 #else
     const std::string msgs_dir = ament_index_cpp::get_package_share_directory("px4_msgs");


### PR DESCRIPTION
On ros rolling and ros lyrical, the current code produces the following error:
```
px4-ros2-interface-lib/px4_ros2_cpp/src/components/message_compatibility_check.cpp:294:78: error: ‘std::string ament_index_cpp::get_package_share_directory(const std::string&)’ is deprecated: Use get_package_share_path(...) instead [-Werror=deprecated-declarations]
  294 |     const std::string msgs_dir = ament_index_cpp::get_package_share_directory("px4_msgs");
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
```

This makes the update to fix the build on the latest rolling.

This was tested on the following:
- Ubuntu 24.04: ROS Rolling
- Ubuntu 26.04: ROS Rolling
- Ubuntu 26.04: ROS Lyrical