### PR TITLE
fix(lateral_longitudinal): add boolean in class constructors to set local position requirement

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/fixedwing/lateral_longitudinal.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/control/setpoint_types/fixedwing/lateral_longitudinal.hpp
@@ -27,7 +27,13 @@ struct FwControlConfiguration;
  */
 class FwLateralLongitudinalSetpointType : public SetpointBase {
  public:
-  explicit FwLateralLongitudinalSetpointType(Context& context);
+  /**
+   * @param context  The mode context.
+   * @param is_position_optional  If true, the mode will not require a valid position estimate.
+   *                              Set to true when only using inner-loop setpoints (lateral
+   *                              acceleration, height rate, airspeed) without course or altitude.
+   */
+  explicit FwLateralLongitudinalSetpointType(Context& context, bool is_position_optional = false);
 
   ~FwLateralLongitudinalSetpointType() override = default;
 
@@ -98,6 +104,7 @@ class FwLateralLongitudinalSetpointType : public SetpointBase {
 
  private:
   rclcpp::Node& _node;
+  bool _local_position_is_optional;
   rclcpp::Publisher<px4_msgs::msg::FixedWingLateralSetpoint>::SharedPtr _fw_lateral_sp_pub;
   rclcpp::Publisher<px4_msgs::msg::FixedWingLongitudinalSetpoint>::SharedPtr
       _fw_longitudinal_sp_pub;

--- a/px4_ros2_cpp/src/control/setpoint_types/fixedwing/lateral_longitudinal.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/fixedwing/lateral_longitudinal.cpp
@@ -10,7 +10,9 @@ namespace px4_ros2 {
 
 FwLateralLongitudinalSetpointType::FwLateralLongitudinalSetpointType(Context& context,
                                                                      bool is_position_optional)
-    : SetpointBase(context), _node(context.node()), _local_position_is_optional(is_position_optional)
+    : SetpointBase(context),
+      _node(context.node()),
+      _local_position_is_optional(is_position_optional)
 {
   _fw_lateral_sp_pub = context.node().create_publisher<px4_msgs::msg::FixedWingLateralSetpoint>(
       context.topicNamespacePrefix() + "fmu/in/fixed_wing_lateral_setpoint" +

--- a/px4_ros2_cpp/src/control/setpoint_types/fixedwing/lateral_longitudinal.cpp
+++ b/px4_ros2_cpp/src/control/setpoint_types/fixedwing/lateral_longitudinal.cpp
@@ -8,8 +8,9 @@
 
 namespace px4_ros2 {
 
-FwLateralLongitudinalSetpointType::FwLateralLongitudinalSetpointType(Context& context)
-    : SetpointBase(context), _node(context.node())
+FwLateralLongitudinalSetpointType::FwLateralLongitudinalSetpointType(Context& context,
+                                                                     bool is_position_optional)
+    : SetpointBase(context), _node(context.node()), _local_position_is_optional(is_position_optional)
 {
   _fw_lateral_sp_pub = context.node().create_publisher<px4_msgs::msg::FixedWingLateralSetpoint>(
       context.topicNamespacePrefix() + "fmu/in/fixed_wing_lateral_setpoint" +
@@ -135,6 +136,7 @@ SetpointBase::Configuration FwLateralLongitudinalSetpointType::getConfiguration(
   config.velocity_enabled = true;
   config.position_enabled = true;
   config.climb_rate_enabled = true;
+  config.local_position_is_optional = _local_position_is_optional;
   return config;
 }
 }  // namespace px4_ros2


### PR DESCRIPTION
### Problem 
As with the trajectory setpoint type, the fixed wing lat/long setpoint exposes inputs at different levels in the controller. Some of these inputs don't require a valid local position - but the mode won't execute because the requirement is placed on the entire setpoint type. 

### Solution 
Adds a boolean in the class constructor to set the requirement on local position. This avoids local position being required when using lower level inputs in the setpoint type. 

Mimics what is already done for the [trajectory setpoint](https://github.com/Auterion/px4-ros2-interface-lib/blob/main/px4_ros2_cpp/src/control/setpoint_types/experimental/trajectory.cpp#L96), as the same problem exists there. 