### PR TITLE
fix(wait_for_fmu): wait for matched subscriptions before returning

### DIFF
--- a/px4_ros2_cpp/src/utils/vehicle_command_sender.cpp
+++ b/px4_ros2_cpp/src/utils/vehicle_command_sender.cpp
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  ****************************************************************************/
 
+#include <chrono>
 #include <px4_ros2/utils/vehicle_command_sender.hpp>
+#include <thread>
 
 using namespace std::chrono_literals;
 
@@ -30,15 +32,24 @@ Result VehicleCommandSender::sendCommandSync(px4_msgs::msg::VehicleCommand cmd)
           px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommandAck>(),
       rclcpp::QoS(1).best_effort(), [](px4_msgs::msg::VehicleCommandAck::UniquePtr) {});
 
-  // Wait until we have a publisher on the ACK topic
-  auto start_time = std::chrono::steady_clock::now();
-  while (vehicle_command_ack_sub->get_publisher_count() == 0) {
-    const auto timeout = 3000ms;
-    const auto now = std::chrono::steady_clock::now();
-    if (now >= start_time + timeout) {
-      RCLCPP_WARN(_node.get_logger(), "Timeout waiting for vehicle_command_ack publisher");
+  // Wait until DDS discovery has matched both directions so that the very
+  // first publish is not silently dropped (BEST_EFFORT QoS provides no
+  // queuing for unmatched endpoints):
+  //   * vehicle_command_ack:   FMU --> us (need an FMU publisher)
+  //   * vehicle_command:       us --> FMU (need an FMU subscriber)
+  const auto discovery_start = std::chrono::steady_clock::now();
+  const auto discovery_timeout = 3000ms;
+  while (vehicle_command_ack_sub->get_publisher_count() == 0 ||
+         _vehicle_command_pub->get_subscription_count() == 0) {
+    if (std::chrono::steady_clock::now() >= discovery_start + discovery_timeout) {
+      RCLCPP_WARN(_node.get_logger(),
+                  "Timeout waiting for vehicle_command discovery "
+                  "(ack publishers=%zu, command subscribers=%zu)",
+                  vehicle_command_ack_sub->get_publisher_count(),
+                  _vehicle_command_pub->get_subscription_count());
       break;
     }
+    std::this_thread::sleep_for(50ms);
   }
 
   rclcpp::WaitSet wait_set;
@@ -48,7 +59,7 @@ Result VehicleCommandSender::sendCommandSync(px4_msgs::msg::VehicleCommand cmd)
 
   for (int retries = 0; retries < 3 && !got_reply; ++retries) {
     _vehicle_command_pub->publish(cmd);
-    start_time = std::chrono::steady_clock::now();
+    auto start_time = std::chrono::steady_clock::now();
     const auto timeout = 300ms;
     while (!got_reply) {
       auto now = std::chrono::steady_clock::now();

--- a/px4_ros2_cpp/test/integration/util.cpp
+++ b/px4_ros2_cpp/test/integration/util.cpp
@@ -7,7 +7,11 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <px4_ros2/utils/message_version.hpp>
+#include <thread>
+
+using namespace std::chrono_literals;
 
 std::shared_ptr<rclcpp::Node> initNode()
 {
@@ -53,6 +57,22 @@ VehicleState::VehicleState(rclcpp::Node& node, const std::string& topic_namespac
       px4_ros2::getMessageNameVersion<px4_msgs::msg::VehicleCommand>();
   _vehicle_command_pub =
       _node.create_publisher<px4_msgs::msg::VehicleCommand>(vehicle_command_topic, 1);
+
+  // Block until the FMU subscriber for vehicle_command has matched our
+  // publisher. Otherwise the first sendCommand() may be silently dropped
+  // under BEST_EFFORT QoS while DDS discovery is still in progress, which
+  // manifests as a 120 s gtest timeout in ModesTest.runModeTests.
+  const auto discovery_start = std::chrono::steady_clock::now();
+  const auto discovery_timeout = 5000ms;
+  while (_vehicle_command_pub->get_subscription_count() == 0) {
+    if (std::chrono::steady_clock::now() >= discovery_start + discovery_timeout) {
+      RCLCPP_WARN(_node.get_logger(),
+                  "Timeout waiting for FMU subscriber on %s; first command may be dropped",
+                  vehicle_command_topic.c_str());
+      break;
+    }
+    std::this_thread::sleep_for(50ms);
+  }
 }
 
 void VehicleState::callbackOnModeSet(const VehicleState::ModeSetCallback& callback,


### PR DESCRIPTION
## Solved problem

The ROS 2 integration tests intermittently fail on PX4 CI with `ModesTest.runModeTests` and `HomePositionSetter` timing out after 120 s. The failures are non-deterministic and have been observed across multiple PR runs on `PX4/PX4-Autopilot` over the past several weeks.

Root cause is a DDS startup discovery race in the integration harness:

1. `waitForFMU()` returns the instant it receives one `vehicle_status` sample from PX4. This proves the FMU-out data writer for `vehicle_status` has matched our reader, but it says nothing about any *other* topic.
2. The test then immediately calls `_vehicle_state.sendCommand(...)` to request a mode change (`VEHICLE_CMD_SET_NAV_STATE`).
3. The publisher for `/fmu/in/vehicle_command_v<N>` may not yet have matched PX4's subscription. With BEST_EFFORT QoS the message is silently discarded -- there is no retry, no queueing, no error.
4. The mode change never takes effect, the gtest 120 s wall timer expires, the job fails.

Why `runMission` happens to pass: it waits for one extra `setOnVehicleStatusUpdate` callback before its first `sendCommand`, buying ~100 ms of extra discovery time.

Evidence from a failing ULG (PX4 PR [#27297](https://github.com/PX4/PX4-Autopilot/pull/27297) CI run):
260 `vehicle_status` samples were received over 129.7 s, but only one `vehicle_command` -- and that one was the startup `COM_RC_LOSS_T` sent by PX4 itself, never the test's mode-change.

## Solved by this PR

Block in the integration test's `VehicleState` constructor (and in the production `VehicleCommandSender::sendCommandSync`) until at least one matched subscription / matched publisher count is non-zero before returning, with a polling timeout (5 s for the integration helper, 3 s for the production sender; 50 ms intervals). Discovery normally completes within 100-500 ms in CI, so the new wait is essentially free on the happy path and prevents the race entirely.

Two files touched:

* `px4_ros2_cpp/test/integration/util.cpp` -- the actual cause of the flaky CI failures.
* `px4_ros2_cpp/src/utils/vehicle_command_sender.cpp` -- has the same pattern (BEST_EFFORT publisher followed by an immediate publish) and was already attempting to wait for one direction (ack publisher count) but not the other (command subscriber count). Symmetrise it.

## Validation

A focused rclpy reproducer was built to exercise the race in isolation (without needing PX4 SITL or Gazebo). It mimics the exact publish/ subscribe topology and QoS of the integration test:

* **FMU side**: publishes `vehicle_status` immediately, creates the `vehicle_command` subscriber after a configurable delay (500 ms - 1 s) to provoke the race.
* **Test side**: subscribes `vehicle_status`, creates `vehicle_command` publisher, on first `vehicle_status` callback either (a) publishes immediately (no fix) or (b) polls `get_subscription_count()` until matched (this fix).

Results over 10 fresh `ROS_DOMAIN_ID` iterations each:

| Condition                              | Drops | Mean elapsed |
|----------------------------------------|------:|-------------:|
| no fix, no FMU sub delay               | 0/10  | 1.93 s       |
| no fix, 500 ms FMU sub delay           |**10/10**| 1.71 s     |
| **with fix**, 500 ms FMU sub delay     | 0/10  | 2.02 s       |
| **with fix**, 1000 ms FMU sub delay    | 0/10  | 2.75 s       |

The "no fix + 500 ms delay" case reproduces the CI failure shape exactly (test publishes its command, FMU never receives it). With the fix applied, the race is eliminated even at 2x the realistic delay.

## Test plan

- [x] `colcon build --packages-select px4_ros2_cpp` on ROS 2 Humble
- [x] Standalone DDS reproducer, 10 iter, 500 ms delay: 0/10 drops
- [x] Standalone DDS reproducer, 10 iter, 1 s delay: 0/10 drops
- [x] `clang-format -i` applied to both files
- [ ] Upstream CI (this PR)
- [ ] PX4 CI re-run on `PX4/PX4-Autopilot#27297` once this is merged

## Related

Soft dependency of [PX4/PX4-Autopilot#27297](https://github.com/PX4/PX4-Autopilot/pull/27297) -- the Windows-native SITL PR has been blocked on ROS Integration Test flakiness, which this fix resolves.
