### PR TITLE
fix(px4_ros2_cpp): add Eigen as a SYSTEM include so -Werror ignores its warnings

### DIFF
--- a/px4_ros2_cpp/CMakeLists.txt
+++ b/px4_ros2_cpp/CMakeLists.txt
@@ -70,7 +70,11 @@ add_custom_command(
 
 add_custom_target(generate_px4_header DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/px4_all_messages.hpp)
 
-include_directories(include SYSTEM ${Eigen3_INCLUDE_DIRS})
+include_directories(include)
+# Eigen headers must be SYSTEM includes so their warnings do not trip the
+# -Werror above. The SYSTEM keyword only takes effect when it precedes the
+# directories, so it needs its own include_directories() call.
+include_directories(SYSTEM ${Eigen3_INCLUDE_DIRS})
 set(HEADER_FILES
         include/px4_ros2/common/setpoint_base.hpp
         include/px4_ros2/components/events.hpp


### PR DESCRIPTION
### Problem

`px4_ros2_cpp/CMakeLists.txt` enables `-Werror`:

```cmake
add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-unused-parameter)
```

and adds Eigen with:

```cmake
include_directories(include SYSTEM ${Eigen3_INCLUDE_DIRS})
```

The `SYSTEM` keyword for `include_directories()` only takes effect when it is the **first** argument (`include_directories([AFTER|BEFORE] [SYSTEM] dirs...)`). Because `include` precedes it here, CMake treats `SYSTEM` as a directory name and adds `${Eigen3_INCLUDE_DIRS}` as a **normal (non-system)** include. Eigen's own header warnings then count against `-Werror`.

This breaks builds that use lower optimization levels. For example a coverage build (`-O0 --coverage`) surfaces `-Wunused-variable` in Eigen's AVX `PacketMath.h` (`F32ToBf16`), and `-Werror` fails the build:

```
/usr/include/eigen3/Eigen/src/Core/arch/AVX/PacketMath.h:1275:13:
  warning: unused variable ‘r’ [-Wunused-variable]
--- stderr: px4_ros2_cpp
Failed   <<< px4_ros2_cpp [exited with code 1]
```

### Fix

Add the local `include` directory and the Eigen **`SYSTEM`** include in separate `include_directories()` calls so Eigen is correctly treated as a system header and its warnings no longer trip `-Werror`.

### Testing

Builds clean with `-Werror`; a coverage/`-O0` build that previously failed on the Eigen `-Wunused-variable` now compiles.