### PR TITLE
Fix setpoint activation sequence (issue #206)

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
@@ -206,6 +206,7 @@ class ModeBase : public Context {
   void updateModeRequirementsFromSetpoints();
   void setSetpointUpdateRateFromSetpointTypes();
   void activateSetpointType(SetpointBase& setpoint);
+  void deactivateAllSetpointTypes();
 
   std::shared_ptr<Registration> _registration;
 

--- a/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
@@ -205,6 +205,7 @@ class ModeBase : public Context {
 
   void updateModeRequirementsFromSetpoints();
   void setSetpointUpdateRateFromSetpointTypes();
+  void publishSetpointConfig(SetpointBase& setpoint);
   void activateSetpointType(SetpointBase& setpoint);
   void deactivateAllSetpointTypes();
 

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -118,7 +118,7 @@ void ModeBase::callOnActivate()
   _is_active = true;
   _completed = false;
   _last_setpoint_update = node().get_clock()->now();
-  deactivateAllSetpointTypes();
+  activateSetpointType(*_setpoint_types[0]);
   onActivate();
 
   if (_setpoint_update_rate_hz > FLT_EPSILON) {
@@ -245,7 +245,7 @@ bool ModeBase::onRegistered()
 
   // TODO: check setpoint types compatibility with current vehicle type
 
-  activateSetpointType(*_setpoint_types[0]);
+  publishSetpointConfig(*_setpoint_types[0]);
   if (_setpoint_update_rate_hz < FLT_EPSILON) {
     // Do not use default setpoint rate if rate was already set by user
     setSetpointUpdateRateFromSetpointTypes();
@@ -293,14 +293,19 @@ void ModeBase::setSetpointUpdateRateFromSetpointTypes()
   }
 }
 
-void ModeBase::activateSetpointType(SetpointBase& setpoint)
+void ModeBase::publishSetpointConfig(SetpointBase& setpoint)
 {
-  setpoint.setActive(true);
   px4_msgs::msg::VehicleControlMode control_mode{};
   control_mode.source_id = static_cast<uint8_t>(id());
   setpoint.getConfiguration().fillControlMode(control_mode);
   control_mode.timestamp = 0;  // Let PX4 set the timestamp
   _config_control_setpoints_pub->publish(control_mode);
+}
+
+void ModeBase::activateSetpointType(SetpointBase& setpoint)
+{
+  setpoint.setActive(true);
+  publishSetpointConfig(setpoint);
 }
 
 void ModeBase::deactivateAllSetpointTypes()

--- a/px4_ros2_cpp/src/components/mode.cpp
+++ b/px4_ros2_cpp/src/components/mode.cpp
@@ -118,6 +118,7 @@ void ModeBase::callOnActivate()
   _is_active = true;
   _completed = false;
   _last_setpoint_update = node().get_clock()->now();
+  deactivateAllSetpointTypes();
   onActivate();
 
   if (_setpoint_update_rate_hz > FLT_EPSILON) {
@@ -131,6 +132,7 @@ void ModeBase::callOnDeactivate()
 {
   RCLCPP_DEBUG(node().get_logger(), "Mode '%s' deactivated", _registration->name().c_str());
   _is_active = false;
+  deactivateAllSetpointTypes();
   onDeactivate();
   updateSetpointUpdateTimer();
 }
@@ -299,6 +301,13 @@ void ModeBase::activateSetpointType(SetpointBase& setpoint)
   setpoint.getConfiguration().fillControlMode(control_mode);
   control_mode.timestamp = 0;  // Let PX4 set the timestamp
   _config_control_setpoints_pub->publish(control_mode);
+}
+
+void ModeBase::deactivateAllSetpointTypes()
+{
+  for (auto& setpoint_type : _setpoint_types) {
+    setpoint_type->setActive(false);
+  }
 }
 
 bool ModeBase::defaultMessageCompatibilityCheck()


### PR DESCRIPTION
# Pull request: fix setpoint activation sequence

This is the fix to the issue described in #206.

## Problem description
Newer PX4 versions refuse control modes that predate mode activation. 

The problem was that `_setpoint_types[0]._active` was being set to `true` prematurely in `onRegistered`. This caused the `SetpointBase._should_activate_cb` method to be skipped, failing to publish a renewed `VehicleControlMode`.

## Overview of changes
Below is a quick overview of the lifecycle process before and after the changes proposed in this pull request:

| Lifecycle Step | Current Behavior | This PR |
| :--- | :--- | :--- |
| **`ModeBase.onRegistered`** | `VehicleControlMode` published.<br>`_setpoint_types[0]._active` is set to `true`. | `VehicleControlMode` published.<br>`_setpoint_types[0]._active` remains `false`. |
| **`ModeBase.callOnActivate`** | `VehicleControlMode` **not** published.<br>`_setpoint_types[0]._active` remains `true`. | `VehicleControlMode` published.<br>`_setpoint_types[0]._active` is set to `true`. |
| **`SetpointBase.onUpdate`** | `_active` is already `true`, so `should_activate_cb()` is **skipped**. | `_active` is now `true`, so `should_activate_cb()` is **skipped**. |

In the current version, no new `VehicleControlMode` gets published after `onRegistered`. This fix would work even if we omitted the changes in `callOnActivate`; in that case, `should_activate_cb` would simply be triggered and publish the `VehicleControlMode` during the very first update loop.