### PR TITLE
fix(integration-tests): inject battery 'wrong' for deferrable low-battery failsafe

### DIFF
--- a/px4_ros2_cpp/test/integration/util.cpp
+++ b/px4_ros2_cpp/test/integration/util.cpp
@@ -114,7 +114,7 @@ void VehicleState::setForceLowBattery(bool enabled)
 {
   sendCommand(px4_msgs::msg::VehicleCommand::VEHICLE_CMD_INJECT_FAILURE,
               px4_msgs::msg::VehicleCommand::FAILURE_UNIT_SYSTEM_BATTERY,
-              enabled ? px4_msgs::msg::VehicleCommand::FAILURE_TYPE_OFF
+              enabled ? px4_msgs::msg::VehicleCommand::FAILURE_TYPE_WRONG
                       : px4_msgs::msg::VehicleCommand::FAILURE_TYPE_OK,
               0);
 }


### PR DESCRIPTION
## Summary
`setForceLowBattery` now injects a battery `wrong` failure instead of `off`, matching the updated PX4 battery failure-injection semantics.

## Problem
PX4 ([PX4-Autopilot#27950](https://github.com/PX4/PX4-Autopilot/pull/27950)) redefines `MAV_CMD_INJECT_FAILURE` battery `off` to mean the pack is disconnected — it suppresses the `battery_status` publication, so the battery reads unhealthy rather than depleted. The depleted-pack behavior that triggers the low-battery failsafe moves to the new `wrong` type. `ModesTest.runExecutorOverrides` uses `setForceLowBattery` (which sent `off`) to trigger a deferrable low-battery failsafe and then waits for the vehicle to land and disarm; with the new semantics `off` no longer produces that failsafe, so the test hangs and times out.

## Solution
Inject `FAILURE_TYPE_WRONG`, which reports a depleted pack and triggers the deferrable low-battery failsafe as before. Depends on[ PX4-Autopilot#27950](https://github.com/PX4/PX4-Autopilot/pull/27950).
