### PR TITLE
chore: bump px4_msgs to 3.5

### DIFF
--- a/px4_ros2_cpp/rosdep-humble.yaml
+++ b/px4_ros2_cpp/rosdep-humble.yaml
@@ -1,3 +1,3 @@
 px4_msgs:
   ubuntu:
-    - ros-humble-px4-msgs=3.4.0-0jammy
+    - ros-humble-px4-msgs=3.5.1-0jammy

--- a/px4_ros2_cpp/rosdep-jazzy.yaml
+++ b/px4_ros2_cpp/rosdep-jazzy.yaml
@@ -1,3 +1,3 @@
 px4_msgs:
   ubuntu:
-    - ros-jazzy-px4-msgs=3.4.0-0noble
+    - ros-jazzy-px4-msgs=3.5.1-0noble

--- a/px4_ros2_cpp/rosdep-rolling.yaml
+++ b/px4_ros2_cpp/rosdep-rolling.yaml
@@ -1,3 +1,3 @@
 px4_msgs:
   ubuntu:
-    - ros-rolling-px4-msgs=3.4.0-0noble
+    - ros-rolling-px4-msgs=3.5.1-0noble


### PR DESCRIPTION
Bumps `px4_msgs` ROS package to 3.5