### PR TITLE
Add watchdog timeout notification callback

### DIFF
--- a/px4_ros2_cpp/include/px4_ros2/components/health_and_arming_checks.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/health_and_arming_checks.hpp
@@ -81,6 +81,7 @@ inline void HealthAndArmingCheckReporter::setHealth(uint8_t health_component_ind
 class HealthAndArmingChecks {
  public:
   using CheckCallback = std::function<void(HealthAndArmingCheckReporter&)>;
+  using WatchdogTimeoutCallback = std::function<void()>;
 
   HealthAndArmingChecks(rclcpp::Node& node, CheckCallback check_callback,
                         const std::string& topic_namespace_prefix = "");
@@ -103,6 +104,14 @@ class HealthAndArmingChecks {
 
   void disableWatchdogTimer() { _watchdog_timer = nullptr; }
 
+  /**
+   * Install a callback that is invoked instead of shutting down the ROS context and throwing when
+   * the FMU watchdog times out. The watchdog timer is cancelled before the callback is invoked.
+   * The callback should schedule re-creation of the health checks or mode object after the current
+   * timer callback returns; the new object will resume watchdog monitoring.
+   */
+  void setWatchdogTimeoutCallback(WatchdogTimeoutCallback callback);
+
  private:
   friend class ModeBase;
   friend class ModeExecutorBase;
@@ -122,6 +131,7 @@ class HealthAndArmingChecks {
   RequirementFlags _mode_requirements{};
   rclcpp::TimerBase::SharedPtr _watchdog_timer;
   bool _shutdown_on_timeout{true};
+  WatchdogTimeoutCallback _watchdog_timeout_callback;
 };
 
 }  // namespace px4_ros2

--- a/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
+++ b/px4_ros2_cpp/include/px4_ros2/components/mode.hpp
@@ -185,6 +185,11 @@ class ModeBase : public Context {
 
   void disableWatchdogTimer() { _health_and_arming_checks.disableWatchdogTimer(); }
 
+  void setWatchdogTimeoutCallback(HealthAndArmingChecks::WatchdogTimeoutCallback callback)
+  {
+    _health_and_arming_checks.setWatchdogTimeoutCallback(std::move(callback));
+  }
+
   bool defaultMessageCompatibilityCheck();
 
  private:

--- a/px4_ros2_cpp/src/components/health_and_arming_checks.cpp
+++ b/px4_ros2_cpp/src/components/health_and_arming_checks.cpp
@@ -83,13 +83,27 @@ bool HealthAndArmingChecks::doRegister(const std::string& name)
   return _registration->doRegister(settings);
 }
 
+void HealthAndArmingChecks::setWatchdogTimeoutCallback(WatchdogTimeoutCallback callback)
+{
+  _watchdog_timeout_callback = std::move(callback);
+}
+
 void HealthAndArmingChecks::watchdogTimerUpdate()
 {
   if (_registration->registered()) {
-    if (!_check_triggered && _shutdown_on_timeout) {
-      rclcpp::shutdown();
-      throw Exception(
-          "Timeout, no request received from FMU, exiting (this can happen on FMU reboots)");
+    if (!_check_triggered) {
+      if (_watchdog_timeout_callback) {
+        _watchdog_timer->cancel();
+        const auto callback = _watchdog_timeout_callback;
+        callback();
+        return;
+      }
+
+      if (_shutdown_on_timeout) {
+        rclcpp::shutdown();
+        throw Exception(
+            "Timeout, no request received from FMU, exiting (this can happen on FMU reboots)");
+      }
     }
 
     _check_triggered = false;


### PR DESCRIPTION
## Summary

- add an optional watchdog timeout callback to `HealthAndArmingChecks`
- expose the callback to derived mode implementations through `ModeBase`
- cancel the watchdog before notifying the application, allowing it to schedule mode re-creation without shutting down the ROS context
- retain the existing shutdown-and-throw behavior when no callback is configured

Fixes #195.

## Testing

Ran the repository pre-commit suite for all changed files, including mixed-line-ending checks, trailing-whitespace checks, and `clang-format`.