### PR TITLE
fix: time waitForFMU with RCL_STEADY_TIME

### DIFF
--- a/px4_ros2_cpp/src/components/wait_for_fmu.cpp
+++ b/px4_ros2_cpp/src/components/wait_for_fmu.cpp
@@ -23,10 +23,11 @@ bool waitForFMU(rclcpp::Node& node, const rclcpp::Duration& discovery_timeout,
           topic, rclcpp::QoS(1).best_effort(), [](px4_msgs::msg::VehicleStatus::UniquePtr msg) {});
 
   // Phase 1: wait for the FMU's vehicle_status publisher to appear on the graph.
+  // RCL_STEADY_TIME: DDS matching is wall time, independent of /clock.
   using namespace std::chrono_literals;  // NOLINT
-  const auto discovery_start = node.now();
+  const auto discovery_start = rclcpp::Clock(RCL_STEADY_TIME).now();
   while (node.count_publishers(topic) == 0) {
-    if (node.now() >= discovery_start + discovery_timeout) {
+    if (rclcpp::Clock(RCL_STEADY_TIME).now() >= discovery_start + discovery_timeout) {
       RCLCPP_DEBUG(node.get_logger(), "timeout while waiting for FMU publisher discovery");
       return false;
     }
@@ -38,10 +39,10 @@ bool waitForFMU(rclcpp::Node& node, const rclcpp::Duration& discovery_timeout,
   wait_set.add_subscription(vehicle_status_sub);
 
   bool got_message = false;
-  const auto heartbeat_start = node.now();
+  const auto heartbeat_start = rclcpp::Clock(RCL_STEADY_TIME).now();
 
   while (!got_message) {
-    const auto now = node.now();
+    const auto now = rclcpp::Clock(RCL_STEADY_TIME).now();
 
     if (now >= heartbeat_start + heartbeat_timeout) {
       break;


### PR DESCRIPTION
## Summary
Use `rclcpp::Clock(RCL_STEADY_TIME)` in `waitForFMU` so timeouts are wall time, not `/clock`.

## Problem
Noticed while restarting external modes in SITL: registration sometimes succeeds, sometimes fails immediately (`timeout while waiting for FMU publisher discovery`). PX4 is already running; the companion node is not.

`waitForFMU` used `node.now()`. With `use_sim_time`, that is 0 until the first `/clock`. If PX4 is already at t=60s, the first stamp is 60s, so `now()` jumps 0 → 60s and `now >= start + 15s` is true immediately. If PX4 time is still <15s, it can pass. DDS discovery is wall time.

See [ROS 2 Clock and Time](https://design.ros2.org/articles/clock_and_time.html): *If time has not been set it will return zero if nothing has been received. A time value of zero should be considered an error meaning that time is uninitialized.*

## Solution
- **wait_for_fmu.cpp**: `rclcpp::Clock(RCL_STEADY_TIME).now()` instead of `node.now()`.