### PR TITLE
fix: increase registration reply timeout to 2s

### DIFF
--- a/px4_ros2_cpp/src/components/registration.cpp
+++ b/px4_ros2_cpp/src/components/registration.cpp
@@ -129,7 +129,7 @@ bool Registration::doRegister(const RegistrationSettings& settings)
     }
 
     const auto start_time = std::chrono::steady_clock::now();
-    const auto timeout = 1000ms;  // CI simulation tests require this to be quite high
+    const auto timeout = 3500ms;  // CI simulation tests require this to be quite high
 
     while (!got_reply) {
       auto now = std::chrono::steady_clock::now();


### PR DESCRIPTION
If the `RegisterExtComponentReply` from PX4 takes longer than the configured
timeout to arrive (slow DDS transport, busy system), the client times out and
retries with a new request. PX4 processes both requests and allocates two slots
for the same mode name -> a duplicate registration.

PX4 is designed to tolerate up to `NUM_NO_REPLY_UNTIL_UNRESPONSIVE_INIT ×
UPDATE_INTERVAL = 10 × 300 ms = 3 s` of unresponsiveness from newly registered
modes, implying DDS latency on slow systems can reach that order of magnitude.
Setting the per-attempt timeout to 3 s ensures the reply arrives before the
retry fires on any system where DDS is functional, preventing the duplicate
registration.